### PR TITLE
Display quote currency

### DIFF
--- a/internal/quote/quote.go
+++ b/internal/quote/quote.go
@@ -10,6 +10,7 @@ import (
 type ResponseQuote struct {
 	ShortName                  string  `json:"shortName"`
 	Symbol                     string  `json:"symbol"`
+	Currency                   string  `json:"currency"`
 	MarketState                string  `json:"marketState"`
 	RegularMarketChange        float64 `json:"regularMarketChange"`
 	RegularMarketChangePercent float64 `json:"regularMarketChangePercent"`

--- a/internal/quote/quote_test.go
+++ b/internal/quote/quote_test.go
@@ -24,7 +24,8 @@ var _ = Describe("Quote", func() {
 							"regularMarketTime": 1608832801,
 							"regularMarketPrice": 84.98,
 							"regularMarketPreviousClose": 81.9,
-							"symbol": "NET"
+							"symbol": "NET",
+							"currency": "USD"
 						}
 					],
 					"error": null
@@ -48,6 +49,7 @@ var _ = Describe("Quote", func() {
 						RegularMarketChangePercent: 3.7606857,
 						RegularMarketPrice:         84.98,
 						RegularMarketPreviousClose: 81.9,
+						Currency:                   "USD",
 					},
 					Price:                   84.98,
 					Change:                  3.0800018,
@@ -75,7 +77,8 @@ var _ = Describe("Quote", func() {
 								"regularMarketTime": 1608832801,
 								"regularMarketPrice": 84.98,
 								"regularMarketPreviousClose": 81.9,
-								"symbol": "NET"
+								"symbol": "NET",
+								"currency": "USD"
 							}
 						],
 						"error": null
@@ -102,6 +105,7 @@ var _ = Describe("Quote", func() {
 							PreMarketChange:            1.0399933,
 							PreMarketChangePercent:     1.2238094,
 							PreMarketPrice:             86.02,
+							Currency:                   "USD",
 						},
 						Price:                   86.02,
 						Change:                  1.0399933,
@@ -130,7 +134,8 @@ var _ = Describe("Quote", func() {
 								"regularMarketTime": 1608832801,
 								"regularMarketPrice": 84.98,
 								"regularMarketPreviousClose": 81.9,
-								"symbol": "NET"
+								"symbol": "NET",
+								"currency": "USD"
 							}
 						],
 						"error": null
@@ -157,6 +162,7 @@ var _ = Describe("Quote", func() {
 							PostMarketChange:           1.0399933,
 							PostMarketChangePercent:    1.2238094,
 							PostMarketPrice:            86.02,
+							Currency:                   "USD",
 						},
 						Price:                   86.02,
 						Change:                  4.1199951,
@@ -185,7 +191,8 @@ var _ = Describe("Quote", func() {
 								"regularMarketTime": 1608832801,
 								"regularMarketPrice": 84.98,
 								"regularMarketPreviousClose": 81.9,
-								"symbol": "NET"
+								"symbol": "NET",
+								"currency": "USD"
 							}
 						],
 						"error": null
@@ -212,6 +219,7 @@ var _ = Describe("Quote", func() {
 							PostMarketChange:           1.0399933,
 							PostMarketChangePercent:    1.2238094,
 							PostMarketPrice:            86.02,
+							Currency:                   "USD",
 						},
 						Price:                   84.98,
 						Change:                  0.0,

--- a/internal/ui/component/watchlist/watchlist.go
+++ b/internal/ui/component/watchlist/watchlist.go
@@ -72,7 +72,7 @@ func item(q quote.Quote, p position.Position, width int) string {
 			},
 			Cell{
 				Width: 25,
-				Text:  styleNeutral(ConvertFloatToString(q.Price)),
+				Text:  styleNeutral(ConvertFloatToString(q.Price) + " " + normalizeCurrency(q.Currency)),
 				Align: RightAlign,
 			},
 		),
@@ -133,6 +133,14 @@ func quoteChangeText(change float64, changePercent float64) string {
 	}
 
 	return stylePriceNegative(changePercent)("↓ " + ConvertFloatToString(change) + " (" + ConvertFloatToString(changePercent) + "%)")
+}
+
+func normalizeCurrency(currency string) string {
+	if currency == "GBp" {
+		return "GBX"
+	}
+
+	return currency
 }
 
 func newStyleFromGradient(startColorHex string, endColorHex string) func(float64) func(string) string {

--- a/internal/ui/component/watchlist/watchlist_test.go
+++ b/internal/ui/component/watchlist/watchlist_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Watchlist", func() {
 					ResponseQuote: ResponseQuote{
 						Symbol:    "AAPL",
 						ShortName: "Apple Inc.",
+						Currency:  "USD",
 					},
 					Price:                   1.00 + change,
 					Change:                  change,
@@ -63,7 +64,7 @@ var _ = Describe("Watchlist", func() {
 			Position{},
 			strings.Join([]string{
 				"",
-				"AAPL                       ⦿                                                1.05",
+				"AAPL                       ⦿                                            1.05 USD",
 				"Apple Inc.                                                       ↑ 0.05  (0.05%)",
 			}, "\n"),
 		),
@@ -75,7 +76,7 @@ var _ = Describe("Watchlist", func() {
 			Position{},
 			strings.Join([]string{
 				"",
-				"AAPL                       ⦿                                                0.95",
+				"AAPL                       ⦿                                            0.95 USD",
 				"Apple Inc.                                                      ↓ -0.05 (-0.05%)",
 			}, "\n"),
 		),
@@ -87,7 +88,7 @@ var _ = Describe("Watchlist", func() {
 			Position{},
 			strings.Join([]string{
 				"",
-				"AAPL                       ⦾                                                1.05",
+				"AAPL                       ⦾                                            1.05 USD",
 				"Apple Inc.                                                       ↑ 0.05  (0.05%)",
 			}, "\n"),
 		),
@@ -108,7 +109,7 @@ var _ = Describe("Watchlist", func() {
 			},
 			strings.Join([]string{
 				"",
-				"AAPL                       ⦿                     105.00                     1.05",
+				"AAPL                       ⦿                     105.00                 1.05 USD",
 				"Apple Inc.                              ↑ 5.00  (5.00%)          ↑ 0.05  (0.05%)",
 			}, "\n"),
 		),
@@ -129,7 +130,7 @@ var _ = Describe("Watchlist", func() {
 			},
 			strings.Join([]string{
 				"",
-				"AAPL                       ⦿                      95.00                     0.95",
+				"AAPL                       ⦿                      95.00                 0.95 USD",
 				"Apple Inc.                             ↓ -5.00 (-5.00%)         ↓ -0.05 (-0.05%)",
 			}, "\n"),
 		),
@@ -150,7 +151,7 @@ var _ = Describe("Watchlist", func() {
 			},
 			strings.Join([]string{
 				"",
-				"AAPL                                              95.00                     1.00",
+				"AAPL                                              95.00                 1.00 USD",
 				"Apple Inc.                                                         0.00  (0.00%)",
 			}, "\n"),
 		),
@@ -166,6 +167,7 @@ var _ = Describe("Watchlist", func() {
 					ResponseQuote: ResponseQuote{
 						Symbol:    "AAPL",
 						ShortName: "Apple Inc.",
+						Currency:  "USD",
 					},
 					Price:                   1.05,
 					Change:                  0.00,
@@ -177,6 +179,7 @@ var _ = Describe("Watchlist", func() {
 					ResponseQuote: ResponseQuote{
 						Symbol:    "TW",
 						ShortName: "ThoughtWorks",
+						Currency:  "USD",
 					},
 					Price:                   109.04,
 					Change:                  3.53,
@@ -188,6 +191,7 @@ var _ = Describe("Watchlist", func() {
 					ResponseQuote: ResponseQuote{
 						Symbol:    "GOOG",
 						ShortName: "Google Inc.",
+						Currency:  "USD",
 					},
 					Price:                   2523.53,
 					Change:                  -32.02,
@@ -199,6 +203,7 @@ var _ = Describe("Watchlist", func() {
 					ResponseQuote: ResponseQuote{
 						Symbol:    "BTC-USD",
 						ShortName: "Bitcoin",
+						Currency:  "USD",
 					},
 					Price:                   50000.0,
 					Change:                  10000.0,
@@ -206,17 +211,31 @@ var _ = Describe("Watchlist", func() {
 					IsActive:                true,
 					IsRegularTradingSession: true,
 				},
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:    "IAG.L",
+						ShortName: "INTERNATIONAL CONSOLIDATED AIRL",
+						Currency:  "GBp",
+					},
+					Price:                   143.0,
+					Change:                  -2.6,
+					ChangePercent:           -1.78,
+					IsActive:                false,
+					IsRegularTradingSession: false,
+				},
 			}
 			expected := strings.Join([]string{
 				"",
-				"BTC-USD                    ⦿                                            50000.00",
+				"BTC-USD                    ⦿                                        50000.00 USD",
 				"Bitcoin                                                     ↑ 10000.00  (20.00%)",
-				"TW                         ⦾                                              109.04",
+				"TW                         ⦾                                          109.04 USD",
 				"ThoughtWorks                                                     ↑ 3.53  (5.65%)",
-				"GOOG                       ⦾                                             2523.53",
+				"GOOG                       ⦾                                         2523.53 USD",
 				"Google Inc.                                                    ↓ -32.02 (-1.35%)",
-				"AAPL                                                                        1.05",
+				"AAPL                                                                    1.05 USD",
 				"Apple Inc.                                                         0.00  (0.00%)",
+				"IAG.L                                                                 143.00 GBX",
+				"INTERNATIONAL CONSOLIDATED AIR                                  ↓ -2.60 (-1.78%)",
 			}, "\n")
 			Expect(removeFormatting(m.View())).To(Equal(expected))
 		})


### PR DESCRIPTION
Hi,

My portfolio contains stocks that are in different currencies. To make it easier to track I have included the currency returned from the API in the UI as follows:

![image](https://user-images.githubusercontent.com/507871/106367017-963f1600-6337-11eb-8667-4ae79f40a5c6.png)

I have also included code to normalise some currencies when returned from the Yahoo API. For example ticker `IAG.L` is in GBP pence which is usually shown as `GBX` but the API is returning it as `GBp`. This is the only case I know but more can be added in the future if needed.

Thanks,
Rob