### PR TITLE
Initialized inputConfigPath variable on failed test

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -405,10 +405,10 @@ var _ = Describe("Cli", func() {
 					inputHome, _ := homedir.Dir()
 					inputConfigHome := inputHome + "/.config"
 					os.Setenv("XDG_CONFIG_HOME", inputConfigHome)
-					inputConfigPath := ""
 					fs.MkdirAll(inputConfigHome, 0755)
-					fs.Create(inputConfigHome + "/.ticker.yaml")
-					afero.WriteFile(fs, inputConfigHome+"/.ticker.yaml", []byte("watchlist:\n  - ABNB"), 0644)
+					inputConfigPath := inputConfigHome + "/.ticker.yaml"
+					fs.Create(inputConfigPath)
+					afero.WriteFile(fs, inputConfigPath, []byte("watchlist:\n  - ABNB"), 0644)
 					config, err := ReadConfig(fs, inputConfigPath)
 					os.Unsetenv("XDG_CONFIG_HOME")
 


### PR DESCRIPTION
Fixed failed test.
I guess there was a tiny mistake in the use of `inputConfigPath` variable (it was "forgotten" and not initialized correctly).
Please watch the changes that I've made in the `cli_test.go` file