### PR TITLE
feat: Added option to use a proxy url

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ticker -w NET,AAPL,TSLA
 |  |--show-tags||display currency, exchange name, and quote delay for each quote |
 |  |--show-fundamentals||display open price, previous close, and day range |
 |  |--show-separator||layout with separators between each quote|
+|  |--proxy||proxy URL for requests (default is none)|
 
 ## Configuration
 
@@ -65,6 +66,7 @@ show-tags: true
 show-fundamentals: true
 show-separator: true
 interval: 10
+proxy: http://localhost:3128
 watchlist:
   - NET
   - TEAM

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	separate              bool
 	extraInfoExchange     bool
 	extraInfoFundamentals bool
+  proxy                 string
 	err                   error
 	rootCmd               = &cobra.Command{
 		Use:   "ticker",
@@ -32,6 +33,7 @@ var (
 				Separate:              &separate,
 				ExtraInfoExchange:     &extraInfoExchange,
 				ExtraInfoFundamentals: &extraInfoFundamentals,
+        Proxy:                 &proxy,
 			},
 			err,
 		),
@@ -54,6 +56,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&separate, "show-separator", false, "layout with separators between each quote")
 	rootCmd.Flags().BoolVar(&extraInfoExchange, "show-tags", false, "display currency, exchange name, and quote delay for each quote")
 	rootCmd.Flags().BoolVar(&extraInfoFundamentals, "show-fundamentals", false, "display open price, high, low, and volume for each quote")
+  rootCmd.Flags().StringVar(&proxy, "proxy", "", "proxy URL for requests (default is none)")
 }
 
 func initConfig() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,6 +21,7 @@ type Config struct {
 	Separate              bool           `yaml:"show-separator"`
 	ExtraInfoExchange     bool           `yaml:"show-tags"`
 	ExtraInfoFundamentals bool           `yaml:"show-fundamentals"`
+  Proxy                 string         `yaml:"proxy"`
 }
 
 type Options struct {
@@ -29,6 +30,7 @@ type Options struct {
 	Separate              *bool
 	ExtraInfoExchange     *bool
 	ExtraInfoFundamentals *bool
+  Proxy                 *string
 }
 
 func Run(uiStartFn func() error) func(*cobra.Command, []string) {
@@ -90,6 +92,7 @@ func mergeConfig(config Config, options Options) Config {
 	config.Separate = getBoolOption(*options.Separate, config.Separate)
 	config.ExtraInfoExchange = getBoolOption(*options.ExtraInfoExchange, config.ExtraInfoExchange)
 	config.ExtraInfoFundamentals = getBoolOption(*options.ExtraInfoFundamentals, config.ExtraInfoFundamentals)
+  config.Proxy = getProxy(*options.Proxy, config.Proxy)
 
 	return config
 }
@@ -130,6 +133,19 @@ func getRefreshInterval(optionsRefreshInterval int, configRefreshInterval int) i
 	}
 
 	return 5
+}
+
+func getProxy(optionsProxy string, configProxy string) string {
+
+  if len(optionsProxy) > 0 {
+    return optionsProxy
+  }
+
+  if len(configProxy) > 0 {
+    return configProxy
+  }
+
+  return ""
 }
 
 func getBoolOption(cliValue bool, configValue bool) bool {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -69,6 +69,7 @@ var _ = Describe("Cli", func() {
 			separate              bool
 			extraInfoExchange     bool
 			extraInfoFundamentals bool
+      proxy                 string
 		)
 
 		BeforeEach(func() {
@@ -78,9 +79,11 @@ var _ = Describe("Cli", func() {
 				Separate:              &separate,
 				ExtraInfoExchange:     &extraInfoExchange,
 				ExtraInfoFundamentals: &extraInfoFundamentals,
+        Proxy:                 &proxy,
 			}
 			watchlist = "GME,BB"
 			refreshInterval = 0
+      proxy = ""
 			separate = false
 			extraInfoExchange = false
 			extraInfoFundamentals = false
@@ -97,6 +100,7 @@ var _ = Describe("Cli", func() {
 					"BB",
 				},
 				Lots: nil,
+        Proxy: "",
 			}
 			outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
 			Expect(outputErr).To(BeNil())
@@ -161,6 +165,50 @@ var _ = Describe("Cli", func() {
 					Expect(inputConfig.Watchlist).To(Equal([]string{
 						"NET",
 					}))
+				})
+			})
+		})
+
+		Describe("proxy url option", func() {
+			When("proxy url is set as a cli argument", func() {
+				It("should set the config to the cli argument value", func() {
+          proxy = "http://localhost:3128"
+					inputConfig := cli.Config{}
+					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+					Expect(outputErr).To(BeNil())
+          Expect(inputConfig.Proxy).To(BeEquivalentTo("http://localhost:3128"))
+				})
+
+				When("the config file also has a proxy url defined", func() {
+					It("should set the proxy url from the cli argument", func() {
+            proxy = "http://www.example.org:3128"
+						inputConfig := cli.Config{
+              Proxy: "http://localhost:3128",
+						}
+						outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+						Expect(outputErr).To(BeNil())
+            Expect(inputConfig.Proxy).To(BeEquivalentTo("http://www.example.org:3128"))
+					})
+				})
+			})
+
+			When("proxy url is set in the config file", func() {
+				It("should set the config to the config argument value", func() {
+					inputConfig := cli.Config{
+            Proxy: "http://localhost:3128",
+					}
+					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+					Expect(outputErr).To(BeNil())
+          Expect(inputConfig.Proxy).To(BeEquivalentTo("http://localhost:3128"))
+				})
+			})
+
+			When("proxy url is not set", func() {
+				It("should set no proxy url", func() {
+					inputConfig := cli.Config{}
+					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+					Expect(outputErr).To(BeNil())
+					Expect(inputConfig.Proxy).To(BeEquivalentTo(""))
 				})
 			})
 		})

--- a/internal/ui/start.go
+++ b/internal/ui/start.go
@@ -10,6 +10,7 @@ import (
 func Start(config *cli.Config) func() error {
 	return func() error {
 		client := resty.New()
+    if len(config.Proxy) > 0 { client.SetProxy(config.Proxy) }
 		p := tea.NewProgram(NewModel(*config, client))
 
 		p.EnableMouseCellMotion()


### PR DESCRIPTION
First pull request and also first thing I've done in go. Therefore, sorry for the chaos in my commits.

I am using a proxy on my machine and thought it'd be neat, if this program makes use of the proxy option that the rest library already provides. So I implemented it.