### PR TITLE
First attempt to make a snap of ticker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 !.goreleaser.yml
 !.github
 !.github/**/*
+!snap/*
 *.coverprofile

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: ticker
+base: core20
+adopt-info: ticker
+summary: Terminal stock watcher and stock position tracker
+description: |
+  Features:
+  Live stock price quotes
+  Track value of your stock positions
+  Support for multiple cost basis lots
+  Support for pre and post market price quotes
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: s390x
+  - build-on: ppc64el
+  - build-on: armhf
+
+parts:
+  ticker:
+    plugin: go
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed -e 's/^v//')"
+
+apps:
+  ticker:
+    command: bin/ticker
+    plugs:
+      - network


### PR DESCRIPTION
Hi. I work on snapcraft for Canonical. Thought I'd take a stab at making a ticker snap. This seems to work for me on Ubuntu and will work on other Linux distros with a simple `snap install ticker`.

![Screenshot from 2021-02-03 14-42-50](https://user-images.githubusercontent.com/1841272/106785849-c9d6b480-6645-11eb-8580-fb0d333651ed.png)

I used this as an opportunity to write a [blog post](https://popey.com/blog/2021/02/lets-go-snapping/) detailing what I did and why. I registered the snap and published it at https://snapcraft.io/ticker however, if you're willing and have the capacity, I'm happy to hand this over to you.

If merged, this can be used with `snapcraft` on Linux or macos to build a snap which can be published to the store. Alternatively you can use our free build service to make snaps and upload automatically on each commit, up to you. As I said, if you're busy or unwilling, I am fine to continue publishing it.