### PR TITLE
Display P/E and P/B

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	refreshInterval       int
 	separate              bool
 	extraInfoExchange     bool
+	extraInfoQuote        bool
 	extraInfoFundamentals bool
 	proxy                 string
 	showSummary           bool
@@ -34,6 +35,7 @@ var (
 				Watchlist:             &watchlist,
 				Separate:              &separate,
 				ExtraInfoExchange:     &extraInfoExchange,
+				ExtraInfoQuote:        &extraInfoQuote,
 				ExtraInfoFundamentals: &extraInfoFundamentals,
 				ShowSummary:           &showSummary,
 				Proxy:                 &proxy,
@@ -59,7 +61,8 @@ func init() {
 	rootCmd.Flags().IntVarP(&refreshInterval, "interval", "i", 0, "refresh interval in seconds")
 	rootCmd.Flags().BoolVar(&separate, "show-separator", false, "layout with separators between each quote")
 	rootCmd.Flags().BoolVar(&extraInfoExchange, "show-tags", false, "display currency, exchange name, and quote delay for each quote")
-	rootCmd.Flags().BoolVar(&extraInfoFundamentals, "show-fundamentals", false, "display open price, high, low, and volume for each quote")
+	rootCmd.Flags().BoolVar(&extraInfoQuote, "show-extended-quote", false, "display open price, high, low, and volume for each quote")
+	rootCmd.Flags().BoolVar(&extraInfoFundamentals, "show-fundamentals", false, "display P/E and P/B for each ticker")
 	rootCmd.Flags().BoolVar(&showSummary, "show-summary", false, "display summary of total gain and loss for positions")
 	rootCmd.Flags().StringVar(&proxy, "proxy", "", "proxy URL for requests (default is none)")
 	rootCmd.Flags().StringVar(&sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. Set \"value\" to sort by position value. Keep empty to sort according to change percent")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,6 +21,7 @@ type Config struct {
 	Lots                  []position.Lot `yaml:"lots"`
 	Separate              bool           `yaml:"show-separator"`
 	ExtraInfoExchange     bool           `yaml:"show-tags"`
+	ExtraInfoQuote        bool           `yaml:"show-extended-quote"`
 	ExtraInfoFundamentals bool           `yaml:"show-fundamentals"`
 	ShowSummary           bool           `yaml:"show-summary"`
 	Proxy                 string         `yaml:"proxy"`
@@ -32,6 +33,7 @@ type Options struct {
 	Watchlist             *string
 	Separate              *bool
 	ExtraInfoExchange     *bool
+	ExtraInfoQuote        *bool
 	ExtraInfoFundamentals *bool
 	ShowSummary           *bool
 	Proxy                 *string
@@ -96,6 +98,7 @@ func mergeConfig(config Config, options Options) Config {
 	config.RefreshInterval = getRefreshInterval(*options.RefreshInterval, config.RefreshInterval)
 	config.Separate = getBoolOption(*options.Separate, config.Separate)
 	config.ExtraInfoExchange = getBoolOption(*options.ExtraInfoExchange, config.ExtraInfoExchange)
+	config.ExtraInfoQuote = getBoolOption(*options.ExtraInfoQuote, config.ExtraInfoQuote)
 	config.ExtraInfoFundamentals = getBoolOption(*options.ExtraInfoFundamentals, config.ExtraInfoFundamentals)
 	config.ShowSummary = getBoolOption(*options.ShowSummary, config.ShowSummary)
 	config.Proxy = getProxy(*options.Proxy, config.Proxy)

--- a/internal/quote/quote.go
+++ b/internal/quote/quote.go
@@ -26,6 +26,8 @@ type ResponseQuote struct {
 	PreMarketChange            float64 `json:"preMarketChange"`
 	PreMarketChangePercent     float64 `json:"preMarketChangePercent"`
 	PreMarketPrice             float64 `json:"preMarketPrice"`
+	PriceToBook                float64 `json:"priceToBook"`
+	TrailingPE                 float64 `json:"trailingPE"`
 }
 
 type Quote struct {

--- a/internal/ui/component/watchlist/watchlist.go
+++ b/internal/ui/component/watchlist/watchlist.go
@@ -19,19 +19,22 @@ type Model struct {
 	Positions             map[string]Position
 	Separate              bool
 	ExtraInfoExchange     bool
+	ExtraInfoQuote        bool
 	ExtraInfoFundamentals bool
 	Sorter                Sorter
 }
 
+type WatchlistModelOption func(*Model)
+
 // NewModel returns a model with default values.
-func NewModel(separate bool, extraInfoExchange bool, extraInfoFundamentals bool, sort string) Model {
-	return Model{
-		Width:                 80,
-		Separate:              separate,
-		ExtraInfoExchange:     extraInfoExchange,
-		ExtraInfoFundamentals: extraInfoFundamentals,
-		Sorter:                NewSorter(sort),
+func NewModel(options ...WatchlistModelOption) Model {
+	m := Model{
+		Width: 80,
 	}
+	for _, option := range options {
+		option(&m)
+	}
+	return m
 }
 
 func (m Model) View() string {
@@ -48,6 +51,7 @@ func (m Model) View() string {
 			strings.Join(
 				[]string{
 					item(quote, m.Positions[quote.Symbol], m.Width),
+					extraInfoQuote(m.ExtraInfoQuote, quote, m.Width),
 					extraInfoFundamentals(m.ExtraInfoFundamentals, quote, m.Width),
 					extraInfoExchange(m.ExtraInfoExchange, quote, m.Width),
 				},
@@ -127,7 +131,7 @@ func extraInfoExchange(show bool, q Quote, width int) string {
 	)
 }
 
-func extraInfoFundamentals(show bool, q Quote, width int) string {
+func extraInfoQuote(show bool, q Quote, width int) string {
 	if !show {
 		return ""
 	}
@@ -144,6 +148,23 @@ func extraInfoFundamentals(show bool, q Quote, width int) string {
 		},
 		Cell{
 			Text: dayRangeText(q.RegularMarketDayRange),
+		},
+	)
+}
+
+func extraInfoFundamentals(show bool, q Quote, width int) string {
+	if !show {
+		return ""
+	}
+
+	return "\n" + Line(
+		width,
+		Cell{
+			Width: 25,
+			Text:  StyleNeutralFaded("P/E: ") + StyleNeutral(ConvertFloatToString(q.TrailingPE)),
+		},
+		Cell{
+			Text: StyleNeutralFaded("P/B: ") + StyleNeutral(ConvertFloatToString(q.PriceToBook)),
 		},
 	)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/achannarasappa/ticker/internal/cli"
 	"github.com/achannarasappa/ticker/internal/position"
 	"github.com/achannarasappa/ticker/internal/quote"
+	"github.com/achannarasappa/ticker/internal/sorter"
 	"github.com/achannarasappa/ticker/internal/ui/component/summary"
 	"github.com/achannarasappa/ticker/internal/ui/component/watchlist"
 
@@ -59,13 +60,21 @@ func NewModel(config cli.Config, client *resty.Client) Model {
 	aggregatedLots := position.GetLots(config.Lots)
 	symbols := position.GetSymbols(config.Watchlist, aggregatedLots)
 
+	watchlistOptions := []watchlist.WatchlistModelOption{
+		func(m *watchlist.Model) { m.Separate = config.Separate },
+		func(m *watchlist.Model) { m.ExtraInfoExchange = config.ExtraInfoExchange },
+		func(m *watchlist.Model) { m.ExtraInfoQuote = config.ExtraInfoQuote },
+		func(m *watchlist.Model) { m.ExtraInfoFundamentals = config.ExtraInfoFundamentals },
+		func(m *watchlist.Model) { m.Sorter = sorter.NewSorter(config.Sort) },
+	}
+
 	return Model{
 		headerHeight:    getVerticalMargin(config),
 		ready:           false,
 		requestInterval: config.RefreshInterval,
 		getQuotes:       quote.GetQuotes(*client, symbols),
 		getPositions:    position.GetPositions(aggregatedLots),
-		watchlist:       watchlist.NewModel(config.Separate, config.ExtraInfoExchange, config.ExtraInfoFundamentals, config.Sort),
+		watchlist:       watchlist.NewModel(watchlistOptions...),
 		summary:         summary.NewModel(),
 	}
 }


### PR DESCRIPTION
Rename --show-fundamentals option to --show-extended-quote since it
shows additional price data rather than fundamentals.

Update --show-fundamentals to display price-to-earnings and
price-to-book for each ticker.