### PR TITLE
Sorting Alphabetically

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var (
 	extraInfoFundamentals bool
 	proxy                 string
 	showSummary           bool
+	sort                  string
 	err                   error
 	rootCmd               = &cobra.Command{
 		Use:   "ticker",
@@ -36,6 +37,7 @@ var (
 				ExtraInfoFundamentals: &extraInfoFundamentals,
 				ShowSummary:           &showSummary,
 				Proxy:                 &proxy,
+				Sort:                  &sort,
 			},
 			err,
 		),
@@ -60,6 +62,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&extraInfoFundamentals, "show-fundamentals", false, "display open price, high, low, and volume for each quote")
 	rootCmd.Flags().BoolVar(&showSummary, "show-summary", false, "display summary of total gain and loss for positions")
 	rootCmd.Flags().StringVar(&proxy, "proxy", "", "proxy URL for requests (default is none)")
+	rootCmd.Flags().StringVar(&sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. keep empty to sort according to change percent")
 }
 
 func initConfig() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,6 +23,7 @@ type Config struct {
 	ExtraInfoFundamentals bool           `yaml:"show-fundamentals"`
 	ShowSummary           bool           `yaml:"show-summary"`
 	Proxy                 string         `yaml:"proxy"`
+	Sort                  string         `yaml:"sort"`
 }
 
 type Options struct {
@@ -33,6 +34,7 @@ type Options struct {
 	ExtraInfoFundamentals *bool
 	ShowSummary           *bool
 	Proxy                 *string
+	Sort                  *string
 }
 
 func Run(uiStartFn func() error) func(*cobra.Command, []string) {
@@ -96,6 +98,7 @@ func mergeConfig(config Config, options Options) Config {
 	config.ExtraInfoFundamentals = getBoolOption(*options.ExtraInfoFundamentals, config.ExtraInfoFundamentals)
 	config.ShowSummary = getBoolOption(*options.ShowSummary, config.ShowSummary)
 	config.Proxy = getProxy(*options.Proxy, config.Proxy)
+	config.Sort = getStringOption(*options.Sort, config.Sort)
 
 	return config
 }
@@ -162,4 +165,17 @@ func getBoolOption(cliValue bool, configValue bool) bool {
 	}
 
 	return false
+}
+
+func getStringOption(cliValue string, configValue string) string {
+
+	if cliValue != "" {
+		return cliValue
+	}
+
+	if configValue != "" {
+		return configValue
+	}
+
+	return ""
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Cli", func() {
 			extraInfoFundamentals bool
 			showSummary           bool
 			proxy                 string
+			sort                  string
 		)
 
 		BeforeEach(func() {
@@ -82,6 +83,7 @@ var _ = Describe("Cli", func() {
 				ExtraInfoFundamentals: &extraInfoFundamentals,
 				ShowSummary:           &showSummary,
 				Proxy:                 &proxy,
+				Sort:                  &sort,
 			}
 			watchlist = "GME,BB"
 			refreshInterval = 0
@@ -90,6 +92,7 @@ var _ = Describe("Cli", func() {
 			extraInfoExchange = false
 			extraInfoFundamentals = false
 			showSummary = false
+			sort = ""
 			fs = afero.NewMemMapFs()
 			//nolint:errcheck
 			fs.MkdirAll("./", 0755)
@@ -105,6 +108,7 @@ var _ = Describe("Cli", func() {
 				},
 				Lots:  nil,
 				Proxy: "",
+				Sort:  "",
 			}
 			outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
 			Expect(outputErr).To(BeNil())
@@ -433,6 +437,50 @@ var _ = Describe("Cli", func() {
 					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
 					Expect(outputErr).To(BeNil())
 					Expect(inputConfig.ShowSummary).To(Equal(false))
+				})
+			})
+		})
+
+		Describe("sort option", func() {
+			When("sort flag is set as a cli argument", func() {
+				It("should set the config to the cli argument value", func() {
+					sort = "symbol"
+					inputConfig := cli.Config{}
+					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+					Expect(outputErr).To(BeNil())
+					Expect(inputConfig.Sort).To(Equal("symbol"))
+				})
+
+				When("the config file also has a sort flag defined", func() {
+					It("should set the sort flag from the cli argument", func() {
+						sort = "symbol"
+						inputConfig := cli.Config{
+							ShowSummary: false,
+						}
+						outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+						Expect(outputErr).To(BeNil())
+						Expect(inputConfig.Sort).To(Equal("symbol"))
+					})
+				})
+			})
+
+			When("sort flag is set in the config file", func() {
+				It("should set the config to the cli argument value", func() {
+					inputConfig := cli.Config{
+						Sort: "symbol",
+					}
+					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+					Expect(outputErr).To(BeNil())
+					Expect(inputConfig.Sort).To(Equal("symbol"))
+				})
+			})
+
+			When("sort flag is not set", func() {
+				It("should disable the option", func() {
+					inputConfig := cli.Config{}
+					outputErr := Validate(&inputConfig, fs, options, nil)(&cobra.Command{}, []string{})
+					Expect(outputErr).To(BeNil())
+					Expect(inputConfig.Sort).To(Equal(""))
 				})
 			})
 		})

--- a/internal/ui/component/watchlist/watchlist_test.go
+++ b/internal/ui/component/watchlist/watchlist_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Watchlist", func() {
 				}
 			}
 
-			m := NewModel(false, false, false)
+			m := NewModel(false, false, false, "")
 			m.Width = 80
 			m.Positions = positionMap
 			m.Quotes = []Quote{
@@ -153,7 +153,7 @@ var _ = Describe("Watchlist", func() {
 	When("there are more than one symbols on the watchlist", func() {
 		It("should render a watchlist with each symbol", func() {
 
-			m := NewModel(false, false, false)
+			m := NewModel(false, false, false, "")
 			m.Width = 80
 			m.Quotes = []Quote{
 				{
@@ -217,7 +217,7 @@ var _ = Describe("Watchlist", func() {
 		When("the show-separator layout flag is set", func() {
 			It("should render a watchlist with separators", func() {
 
-				m := NewModel(true, false, false)
+				m := NewModel(true, false, false, "")
 				m.Quotes = []Quote{
 					{
 						ResponseQuote: ResponseQuote{
@@ -270,7 +270,7 @@ var _ = Describe("Watchlist", func() {
 
 	When("the option for extra exchange information is set", func() {
 		It("should render extra exchange information", func() {
-			m := NewModel(true, true, false)
+			m := NewModel(true, true, false, "")
 			m.Quotes = []Quote{
 				{
 					ResponseQuote: ResponseQuote{
@@ -297,7 +297,7 @@ var _ = Describe("Watchlist", func() {
 
 		When("the exchange has a delay", func() {
 			It("should render extra exchange information with the delay amount", func() {
-				m := NewModel(true, true, false)
+				m := NewModel(true, true, false, "")
 				m.Quotes = []Quote{
 					{
 						ResponseQuote: ResponseQuote{
@@ -326,7 +326,7 @@ var _ = Describe("Watchlist", func() {
 
 	When("the option for extra fundamental information is set", func() {
 		It("should render extra fundamental information", func() {
-			m := NewModel(true, false, true)
+			m := NewModel(true, false, true, "")
 			m.Quotes = []Quote{
 				{
 					ResponseQuote: ResponseQuote{
@@ -353,7 +353,7 @@ var _ = Describe("Watchlist", func() {
 
 		When("there is no day range", func() {
 			It("should not render the day range field", func() {
-				m := NewModel(true, false, true)
+				m := NewModel(true, false, true, "")
 				m.Quotes = []Quote{
 					{
 						ResponseQuote: ResponseQuote{
@@ -379,16 +379,126 @@ var _ = Describe("Watchlist", func() {
 		})
 	})
 
+	When("the option for sort is set to 'alpha'", func() {
+		It("should render quotes alphabetically", func() {
+			m := NewModel(true, false, false, "alpha")
+			m.Quotes = []Quote{
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:                     "BTC-USD",
+						ShortName:                  "Bitcoin",
+						RegularMarketPreviousClose: 10000.0,
+						RegularMarketOpen:          10000.0,
+						RegularMarketDayRange:      "10000 - 10000",
+					},
+					Price:                   50000.0,
+					Change:                  10000.0,
+					ChangePercent:           20.0,
+					IsActive:                true,
+					IsRegularTradingSession: true,
+				},
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:    "TW",
+						ShortName: "ThoughtWorks",
+					},
+					Price:                   109.04,
+					Change:                  3.53,
+					ChangePercent:           5.65,
+					IsActive:                true,
+					IsRegularTradingSession: false,
+				},
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:    "GOOG",
+						ShortName: "Google Inc.",
+					},
+					Price:                   2523.53,
+					Change:                  -32.02,
+					ChangePercent:           -1.35,
+					IsActive:                true,
+					IsRegularTradingSession: false,
+				},
+			}
+			expected := strings.Join([]string{
+				"BTC-USD                    ⦿                                            50000.00",
+				"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+				"⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
+				"GOOG                       ⦾                                             2523.53",
+				"Google Inc.                                                    ↓ -32.02 (-1.35%)",
+				"⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
+				"TW                         ⦾                                              109.04",
+				"ThoughtWorks                                                     ↑ 3.53  (5.65%)",
+			}, "\n")
+			Expect(removeFormatting(m.View())).To(Equal(expected))
+		})
+	})
+
+	When("the sort option isn't set", func() {
+		It("should render quotes by change percent", func() {
+			m := NewModel(true, false, false, "")
+			m.Quotes = []Quote{
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:                     "BTC-USD",
+						ShortName:                  "Bitcoin",
+						RegularMarketPreviousClose: 10000.0,
+						RegularMarketOpen:          10000.0,
+						RegularMarketDayRange:      "10000 - 10000",
+					},
+					Price:                   50000.0,
+					Change:                  10000.0,
+					ChangePercent:           20.0,
+					IsActive:                true,
+					IsRegularTradingSession: true,
+				},
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:    "TW",
+						ShortName: "ThoughtWorks",
+					},
+					Price:                   109.04,
+					Change:                  3.53,
+					ChangePercent:           5.65,
+					IsActive:                true,
+					IsRegularTradingSession: false,
+				},
+				{
+					ResponseQuote: ResponseQuote{
+						Symbol:    "GOOG",
+						ShortName: "Google Inc.",
+					},
+					Price:                   2523.53,
+					Change:                  -32.02,
+					ChangePercent:           -1.35,
+					IsActive:                true,
+					IsRegularTradingSession: false,
+				},
+			}
+			expected := strings.Join([]string{
+				"BTC-USD                    ⦿                                            50000.00",
+				"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+				"⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
+				"TW                         ⦾                                              109.04",
+				"ThoughtWorks                                                     ↑ 3.53  (5.65%)",
+				"⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
+				"GOOG                       ⦾                                             2523.53",
+				"Google Inc.                                                    ↓ -32.02 (-1.35%)",
+			}, "\n")
+			Expect(removeFormatting(m.View())).To(Equal(expected))
+		})
+	})
+
 	When("no quotes are set", func() {
 		It("should render an empty watchlist", func() {
-			m := NewModel(false, false, false)
+			m := NewModel(false, false, false, "")
 			Expect(m.View()).To(Equal(""))
 		})
 	})
 
 	When("the window width is less than the minimum", func() {
 		It("should render an empty watchlist", func() {
-			m := NewModel(false, false, false)
+			m := NewModel(false, false, false, "")
 			m.Width = 70
 			Expect(m.View()).To(Equal("Terminal window too narrow to render content\nResize to fix (70/80)"))
 		})

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -64,7 +64,7 @@ func NewModel(config cli.Config, client *resty.Client) Model {
 		requestInterval: 3,
 		getQuotes:       quote.GetQuotes(*client, symbols),
 		getPositions:    position.GetPositions(aggregatedLots),
-		watchlist:       watchlist.NewModel(config.Separate, config.ExtraInfoExchange, config.ExtraInfoFundamentals),
+		watchlist:       watchlist.NewModel(config.Separate, config.ExtraInfoExchange, config.ExtraInfoFundamentals, config.Sort),
 		summary:         summary.NewModel(),
 	}
 }


### PR DESCRIPTION
I'm opening new PR because my last one (#21 ) didn't pass all the checks.

[quote](https://github.com/achannarasappa/ticker/pull/21#issuecomment-772876751) by @achannarasappa 

> commitlint check is failing (have a look here for the spec)

------------


What I did?
-
Added an option to sort the quotes by alphabetically.
The quotes are sorted according to the `sort` argument (from configuration file or the cli arguments).
Default sort is by **ChangePercent**.
It is a suggestion to expand to functionality of Sorting. according to issue #5 

How I did it
-
Changed sortQuotes function in watchlist.go and "appended" the relevant order by functionality according to sort-quotes-by argument.

How to verify it
-
In the configuration file (ticker.yaml) or as an argument in the CLI, Set Symbol as the value of the flag sort-quotes-by in order to verify that the quotes are ordered by symbol name.
In case of omitting this argument (default behaviour), quotes will be ordered by the change percentage.

