### PR TITLE
Allow Sort Order To Be Changed

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	refreshInterval       int
 	separate              bool
 	extraInfoExchange     bool
+	extraInfoQuote        bool
 	extraInfoFundamentals bool
 	proxy                 string
 	showSummary           bool
@@ -34,6 +35,7 @@ var (
 				Watchlist:             &watchlist,
 				Separate:              &separate,
 				ExtraInfoExchange:     &extraInfoExchange,
+				ExtraInfoQuote:        &extraInfoQuote,
 				ExtraInfoFundamentals: &extraInfoFundamentals,
 				ShowSummary:           &showSummary,
 				Proxy:                 &proxy,
@@ -59,7 +61,8 @@ func init() {
 	rootCmd.Flags().IntVarP(&refreshInterval, "interval", "i", 0, "refresh interval in seconds")
 	rootCmd.Flags().BoolVar(&separate, "show-separator", false, "layout with separators between each quote")
 	rootCmd.Flags().BoolVar(&extraInfoExchange, "show-tags", false, "display currency, exchange name, and quote delay for each quote")
-	rootCmd.Flags().BoolVar(&extraInfoFundamentals, "show-fundamentals", false, "display open price, high, low, and volume for each quote")
+	rootCmd.Flags().BoolVar(&extraInfoQuote, "show-extended-quote", false, "display open price, high, low, and volume for each quote")
+	rootCmd.Flags().BoolVar(&extraInfoFundamentals, "show-fundamentals", false, "display P/E and P/B for each ticker")
 	rootCmd.Flags().BoolVar(&showSummary, "show-summary", false, "display summary of total gain and loss for positions")
 	rootCmd.Flags().StringVar(&proxy, "proxy", "", "proxy URL for requests (default is none)")
 	rootCmd.Flags().StringVar(&sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. Set \"value\" to sort by position value. Keep empty to sort according to change percent")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,6 +21,7 @@ type Config struct {
 	Lots                  []position.Lot `yaml:"lots"`
 	Separate              bool           `yaml:"show-separator"`
 	ExtraInfoExchange     bool           `yaml:"show-tags"`
+	ExtraInfoQuote        bool           `yaml:"show-extended-quote"`
 	ExtraInfoFundamentals bool           `yaml:"show-fundamentals"`
 	ShowSummary           bool           `yaml:"show-summary"`
 	Proxy                 string         `yaml:"proxy"`
@@ -32,6 +33,7 @@ type Options struct {
 	Watchlist             *string
 	Separate              *bool
 	ExtraInfoExchange     *bool
+	ExtraInfoQuote        *bool
 	ExtraInfoFundamentals *bool
 	ShowSummary           *bool
 	Proxy                 *string
@@ -96,6 +98,7 @@ func mergeConfig(config Config, options Options) Config {
 	config.RefreshInterval = getRefreshInterval(*options.RefreshInterval, config.RefreshInterval)
 	config.Separate = getBoolOption(*options.Separate, config.Separate)
 	config.ExtraInfoExchange = getBoolOption(*options.ExtraInfoExchange, config.ExtraInfoExchange)
+	config.ExtraInfoQuote = getBoolOption(*options.ExtraInfoQuote, config.ExtraInfoQuote)
 	config.ExtraInfoFundamentals = getBoolOption(*options.ExtraInfoFundamentals, config.ExtraInfoFundamentals)
 	config.ShowSummary = getBoolOption(*options.ShowSummary, config.ShowSummary)
 	config.Proxy = getProxy(*options.Proxy, config.Proxy)

--- a/internal/quote/quote.go
+++ b/internal/quote/quote.go
@@ -26,6 +26,8 @@ type ResponseQuote struct {
 	PreMarketChange            float64 `json:"preMarketChange"`
 	PreMarketChangePercent     float64 `json:"preMarketChangePercent"`
 	PreMarketPrice             float64 `json:"preMarketPrice"`
+	PriceToBook                float64 `json:"priceToBook"`
+	TrailingPE                 float64 `json:"trailingPE"`
 }
 
 type Quote struct {

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Sorter", func() {
 			It("should sort by default (change percent)", func() {
 				sorter := NewSorter("")
 
-				sortedQuotes := sorter(quotes, positions)
+				sortedQuotes := sorter.Sort(quotes, positions)
 				expected := []Quote{
 					bitcoinQuote,
 					twQuote,
@@ -93,7 +93,7 @@ var _ = Describe("Sorter", func() {
 			It("should sort by alphabetical order", func() {
 				sorter := NewSorter("alpha")
 
-				sortedQuotes := sorter(quotes, positions)
+				sortedQuotes := sorter.Sort(quotes, positions)
 				expected := []Quote{
 					bitcoinQuote,
 					googleQuote,
@@ -104,11 +104,27 @@ var _ = Describe("Sorter", func() {
 				Expect(sortedQuotes).To(Equal(expected))
 			})
 		})
+		When("sort is reversed", func() {
+			It("should sort by reverse alphabetical order", func() {
+				sorter := NewSorter("alpha")
+
+				sorter.Reverse = true
+				sortedQuotes := sorter.Sort(quotes, positions)
+				expected := []Quote{
+					twQuote,
+					msftQuote,
+					googleQuote,
+					bitcoinQuote,
+				}
+
+				Expect(sortedQuotes).To(Equal(expected))
+			})
+		})
 		When("providing \"position\" as a sort parameter", func() {
 			It("should sort position value, with inactive quotes last", func() {
 				sorter := NewSorter("value")
 
-				sortedQuotes := sorter(quotes, positions)
+				sortedQuotes := sorter.Sort(quotes, positions)
 				expected := []Quote{
 					bitcoinQuote,
 					googleQuote,
@@ -124,7 +140,7 @@ var _ = Describe("Sorter", func() {
 				It("should return no quotes", func() {
 					sorter := NewSorter("")
 
-					sortedQuotes := sorter([]Quote{}, map[string]Position{})
+					sortedQuotes := sorter.Sort([]Quote{}, map[string]Position{})
 					expected := []Quote{}
 					Expect(sortedQuotes).To(Equal(expected))
 				})
@@ -133,7 +149,7 @@ var _ = Describe("Sorter", func() {
 				It("should return no quotes", func() {
 					sorter := NewSorter("alpha")
 
-					sortedQuotes := sorter([]Quote{}, map[string]Position{})
+					sortedQuotes := sorter.Sort([]Quote{}, map[string]Position{})
 					expected := []Quote{}
 					Expect(sortedQuotes).To(Equal(expected))
 				})
@@ -142,7 +158,7 @@ var _ = Describe("Sorter", func() {
 				It("should return no quotes", func() {
 					sorter := NewSorter("value")
 
-					sortedQuotes := sorter([]Quote{}, map[string]Position{})
+					sortedQuotes := sorter.Sort([]Quote{}, map[string]Position{})
 					expected := []Quote{}
 					Expect(sortedQuotes).To(Equal(expected))
 				})

--- a/internal/ui/component/watchlist/watchlist.go
+++ b/internal/ui/component/watchlist/watchlist.go
@@ -43,7 +43,7 @@ func (m Model) View() string {
 		return fmt.Sprintf("Terminal window too narrow to render content\nResize to fix (%d/80)", m.Width)
 	}
 
-	quotes := m.Sorter(m.Quotes, m.Positions)
+	quotes := m.Sort(m.Quotes, m.Positions)
 	items := make([]string, 0)
 	for _, quote := range quotes {
 		items = append(
@@ -61,6 +61,10 @@ func (m Model) View() string {
 	}
 
 	return strings.Join(items, separator(m.Separate, m.Width))
+}
+
+func (m Model) Sort(quotes []Quote, positions map[string]Position) []Quote {
+	return m.Sorter.Sort(m.Quotes, m.Positions)
 }
 
 func separator(isSeparated bool, width int) string {

--- a/internal/ui/component/watchlist/watchlist.go
+++ b/internal/ui/component/watchlist/watchlist.go
@@ -19,19 +19,22 @@ type Model struct {
 	Positions             map[string]Position
 	Separate              bool
 	ExtraInfoExchange     bool
+	ExtraInfoQuote        bool
 	ExtraInfoFundamentals bool
 	Sorter                Sorter
 }
 
+type WatchlistModelOption func(*Model)
+
 // NewModel returns a model with default values.
-func NewModel(separate bool, extraInfoExchange bool, extraInfoFundamentals bool, sort string) Model {
-	return Model{
-		Width:                 80,
-		Separate:              separate,
-		ExtraInfoExchange:     extraInfoExchange,
-		ExtraInfoFundamentals: extraInfoFundamentals,
-		Sorter:                NewSorter(sort),
+func NewModel(options ...WatchlistModelOption) Model {
+	m := Model{
+		Width: 80,
 	}
+	for _, option := range options {
+		option(&m)
+	}
+	return m
 }
 
 func (m Model) View() string {
@@ -48,6 +51,7 @@ func (m Model) View() string {
 			strings.Join(
 				[]string{
 					item(quote, m.Positions[quote.Symbol], m.Width),
+					extraInfoQuote(m.ExtraInfoQuote, quote, m.Width),
 					extraInfoFundamentals(m.ExtraInfoFundamentals, quote, m.Width),
 					extraInfoExchange(m.ExtraInfoExchange, quote, m.Width),
 				},
@@ -127,7 +131,7 @@ func extraInfoExchange(show bool, q Quote, width int) string {
 	)
 }
 
-func extraInfoFundamentals(show bool, q Quote, width int) string {
+func extraInfoQuote(show bool, q Quote, width int) string {
 	if !show {
 		return ""
 	}
@@ -144,6 +148,23 @@ func extraInfoFundamentals(show bool, q Quote, width int) string {
 		},
 		Cell{
 			Text: dayRangeText(q.RegularMarketDayRange),
+		},
+	)
+}
+
+func extraInfoFundamentals(show bool, q Quote, width int) string {
+	if !show {
+		return ""
+	}
+
+	return "\n" + Line(
+		width,
+		Cell{
+			Width: 25,
+			Text:  StyleNeutralFaded("P/E: ") + StyleNeutral(ConvertFloatToString(q.TrailingPE)),
+		},
+		Cell{
+			Text: StyleNeutralFaded("P/B: ") + StyleNeutral(ConvertFloatToString(q.PriceToBook)),
 		},
 	)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/achannarasappa/ticker/internal/cli"
 	"github.com/achannarasappa/ticker/internal/position"
 	"github.com/achannarasappa/ticker/internal/quote"
+	"github.com/achannarasappa/ticker/internal/sorter"
 	"github.com/achannarasappa/ticker/internal/ui/component/summary"
 	"github.com/achannarasappa/ticker/internal/ui/component/watchlist"
 
@@ -59,13 +60,21 @@ func NewModel(config cli.Config, client *resty.Client) Model {
 	aggregatedLots := position.GetLots(config.Lots)
 	symbols := position.GetSymbols(config.Watchlist, aggregatedLots)
 
+	watchlistOptions := []watchlist.WatchlistModelOption{
+		func(m *watchlist.Model) { m.Separate = config.Separate },
+		func(m *watchlist.Model) { m.ExtraInfoExchange = config.ExtraInfoExchange },
+		func(m *watchlist.Model) { m.ExtraInfoQuote = config.ExtraInfoQuote },
+		func(m *watchlist.Model) { m.ExtraInfoFundamentals = config.ExtraInfoFundamentals },
+		func(m *watchlist.Model) { m.Sorter = sorter.NewSorter(config.Sort) },
+	}
+
 	return Model{
 		headerHeight:    getVerticalMargin(config),
 		ready:           false,
 		requestInterval: config.RefreshInterval,
 		getQuotes:       quote.GetQuotes(*client, symbols),
 		getPositions:    position.GetPositions(aggregatedLots),
-		watchlist:       watchlist.NewModel(config.Separate, config.ExtraInfoExchange, config.ExtraInfoFundamentals, config.Sort),
+		watchlist:       watchlist.NewModel(watchlistOptions...),
 		summary:         summary.NewModel(),
 	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -95,10 +95,24 @@ type QuoteMsg struct {
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
+	sorters := map[string]string{
+		"t": "alpha",
+		"c": "change",
+		"e": "pe",
+		"p": "value",
+		"b": "pb",
+	}
+
 	switch msg := msg.(type) {
 
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "t", "c", "e", "b", "p":
+			m.watchlist.Sorter = sorter.NewSorter(sorters[msg.String()])
+			m.viewport.SetContent(m.watchlist.View())
+		case "r":
+			m.watchlist.Sorter.Reverse = !m.watchlist.Sorter.Reverse
+			m.viewport.SetContent(m.watchlist.View())
 		case "ctrl+c":
 			fallthrough
 		case "esc":


### PR DESCRIPTION
Use key strokes to switch sort order between (t)icker, day's (c)hange,
price-to-(e)arnings, and price-to-(b)ook, and to (r)everse the order.

_[Includes fundamentals changes in #54]_
