### PR TITLE
Multi arch docker support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,20 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       -
         name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Docker Login
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,7 +65,7 @@ dockers:
 - image_templates: ["goticker/ticker:{{ .Version }}-arm64v8"]
   binaries: [ticker]
   goarch: arm64
-  dockerfile: goreleaser.Dockerfile
+  dockerfile: Dockerfile
   use_buildx: true
   build_flag_templates:
   - "--platform=linux/arm64/v8"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,26 +35,48 @@ checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
 release:
   github:
-      owner: achannarasappa
+      owner: junior
       name: ticker
-brews:
-  -
-    name: ticker
-    tap:
-      owner: achannarasappa
-      name: tap
-    commit_author:
-      name: achannarasappa
-      email: git@ani.dev
-    homepage: "https://github.com/achannarasappa/ticker"
-    description: "Terminal stock ticker with live updates and position tracking"
-    license: "GPLv3"
+# brews:
+#   -
+#     name: ticker
+#     tap:
+#       owner: achannarasappa
+#       name: tap
+#     commit_author:
+#       name: achannarasappa
+#       email: git@ani.dev
+#     homepage: "https://github.com/achannarasappa/ticker"
+#     description: "Terminal stock ticker with live updates and position tracking"
+#     license: "GPLv3"
 dockers:
-  -
-    goos: linux
-    goarch: amd64
-    image_templates:
-    - "achannarasappa/ticker:{{ .Tag }}"
-    - "achannarasappa/ticker:v{{ .Major }}"
-    - "achannarasappa/ticker:v{{ .Major }}.{{ .Minor }}"
-    - "achannarasappa/ticker:latest"
+- image_templates: ["goticker/ticker:{{ .Version }}-amd64"]
+  binaries: [ticker]
+  dockerfile: Dockerfile
+  use_buildx: true
+  build_flag_templates:
+  - "--platform=linux/amd64"
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+- image_templates: ["goticker/ticker:{{ .Version }}-arm64v8"]
+  binaries: [ticker]
+  goarch: arm64
+  dockerfile: goreleaser.Dockerfile
+  use_buildx: true
+  build_flag_templates:
+  - "--platform=linux/arm64/v8"
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+docker_manifests:
+- name_template: goticker/ticker:{{ .Version }}
+  image_templates:
+  - goticker/ticker:{{ .Version }}-amd64
+  - goticker/ticker:{{ .Version }}-arm64v8

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,20 +35,20 @@ checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
 release:
   github:
-      owner: junior
+      owner: achannarasappa
       name: ticker
-# brews:
-#   -
-#     name: ticker
-#     tap:
-#       owner: achannarasappa
-#       name: tap
-#     commit_author:
-#       name: achannarasappa
-#       email: git@ani.dev
-#     homepage: "https://github.com/achannarasappa/ticker"
-#     description: "Terminal stock ticker with live updates and position tracking"
-#     license: "GPLv3"
+brews:
+  -
+    name: ticker
+    tap:
+      owner: achannarasappa
+      name: tap
+    commit_author:
+      name: achannarasappa
+      email: git@ani.dev
+    homepage: "https://github.com/achannarasappa/ticker"
+    description: "Terminal stock ticker with live updates and position tracking"
+    license: "GPLv3"
 dockers:
 - image_templates: ["goticker/ticker:{{ .Version }}-amd64"]
   binaries: [ticker]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,3 +80,4 @@ docker_manifests:
   image_templates:
   - goticker/ticker:{{ .Version }}-amd64
   - goticker/ticker:{{ .Version }}-arm64v8
+  - goticker/ticker:latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ brews:
     description: "Terminal stock ticker with live updates and position tracking"
     license: "GPLv3"
 dockers:
-- image_templates: ["goticker/ticker:{{ .Version }}-amd64"]
+- image_templates: ["achannarasappa/ticker:{{ .Version }}-amd64"]
   binaries: [ticker]
   dockerfile: Dockerfile
   use_buildx: true
@@ -62,7 +62,7 @@ dockers:
   - "--label=org.opencontainers.image.revision={{.FullCommit}}"
   - "--label=org.opencontainers.image.version={{.Version}}"
   - "--label=org.opencontainers.image.source={{.GitURL}}"
-- image_templates: ["goticker/ticker:{{ .Version }}-arm64v8"]
+- image_templates: ["achannarasappa/ticker:{{ .Version }}-arm64v8"]
   binaries: [ticker]
   goarch: arm64
   dockerfile: Dockerfile
@@ -76,23 +76,23 @@ dockers:
   - "--label=org.opencontainers.image.version={{.Version}}"
   - "--label=org.opencontainers.image.source={{.GitURL}}"
 docker_manifests:
-- name_template: goticker/ticker:{{ .Version }}
+- name_template: achannarasappa/ticker:{{ .Version }}
   image_templates:
-  - goticker/ticker:{{ .Version }}-amd64
-  - goticker/ticker:{{ .Version }}-arm64v8
-- name_template: goticker/ticker:latest
+  - achannarasappa/ticker:{{ .Version }}-amd64
+  - achannarasappa/ticker:{{ .Version }}-arm64v8
+- name_template: achannarasappa/ticker:latest
   image_templates:
-  - goticker/ticker:{{ .Version }}-amd64
-  - goticker/ticker:{{ .Version }}-arm64v8
-- name_template: goticker/ticker:{{ .Major }}
+  - achannarasappa/ticker:{{ .Version }}-amd64
+  - achannarasappa/ticker:{{ .Version }}-arm64v8
+- name_template: achannarasappa/ticker:{{ .Major }}
   image_templates:
-  - goticker/ticker:{{ .Version }}-amd64
-  - goticker/ticker:{{ .Version }}-arm64v8
-- name_template: goticker/ticker:{{ .Major }}.{{ .Minor }}
+  - achannarasappa/ticker:{{ .Version }}-amd64
+  - achannarasappa/ticker:{{ .Version }}-arm64v8
+- name_template: achannarasappa/ticker:{{ .Major }}.{{ .Minor }}
   image_templates:
-  - goticker/ticker:{{ .Version }}-amd64
-  - goticker/ticker:{{ .Version }}-arm64v8
-- name_template: goticker/ticker:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+  - achannarasappa/ticker:{{ .Version }}-amd64
+  - achannarasappa/ticker:{{ .Version }}-arm64v8
+- name_template: achannarasappa/ticker:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
   image_templates:
-  - goticker/ticker:{{ .Version }}-amd64
-  - goticker/ticker:{{ .Version }}-arm64v8
+  - achannarasappa/ticker:{{ .Version }}-amd64
+  - achannarasappa/ticker:{{ .Version }}-arm64v8

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,4 +80,19 @@ docker_manifests:
   image_templates:
   - goticker/ticker:{{ .Version }}-amd64
   - goticker/ticker:{{ .Version }}-arm64v8
-  - goticker/ticker:latest
+- name_template: goticker/ticker:latest
+  image_templates:
+  - goticker/ticker:{{ .Version }}-amd64
+  - goticker/ticker:{{ .Version }}-arm64v8
+- name_template: goticker/ticker:{{ .Major }}
+  image_templates:
+  - goticker/ticker:{{ .Version }}-amd64
+  - goticker/ticker:{{ .Version }}-arm64v8
+- name_template: goticker/ticker:{{ .Major }}.{{ .Minor }}
+  image_templates:
+  - goticker/ticker:{{ .Version }}-amd64
+  - goticker/ticker:{{ .Version }}-arm64v8
+- name_template: goticker/ticker:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+  image_templates:
+  - goticker/ticker:{{ .Version }}-amd64
+  - goticker/ticker:{{ .Version }}-arm64v8


### PR DESCRIPTION
Fixes issue #82 

Extends Docker support to Multi-arch images, including linux/amd64 and linux/arm64 platforms, allowing run Ticker on arm, like Docker on Apple Silicon and Docker on Raspberry Pi

Also introduces easy address for docker runs: 


```shell
docker run -it --rm achannarasappa/ticker -w BTC-USD,AAPL,TSLA
```
~`docker run -it --rm goticker/ticker -w BTC-USD,AAPL,TSLA`~

~https://hub.docker.com/r/goticker/ticker~