### PR TITLE
feat: Add TD Ameritrade positions syncing

### DIFF
--- a/get_td_token.sh
+++ b/get_td_token.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# This script is a hacky helper that should be removed once we add support
+# for the TD oauth flow (acquiring initial token and refreshing)
+#
+# Usage:
+# TD_CONSUMER_KEY=<your_application_id> ./get_td_token.sh
+
+# DEPENDENCIES:
+#   - python3
+#   - curl
+#   - jq
+
+cd $(dirname $0)
+
+[[ -n "$TD_CONSUMER_KEY" ]] || { echo "Please set TD_CONSUMER_KEY"; exit 1; }
+
+TD_REDIRECT_URI=${TD_REDIRECT_URI:-https://127.0.0.1:42068/callback}
+
+uriencode() {
+    # cheating... i know...
+    python -c "import urllib.parse; print(urllib.parse.quote('''$1'''))"
+}
+
+uridecode() {
+    python -c "import urllib.parse; print(urllib.parse.unquote('''$1'''))"
+}
+
+get_new_auth() {
+    xdg-open "https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=$(uriencode $TD_REDIRECT_URI)&client_id=$(uriencode $TD_CONSUMER_KEY)%40AMER.OAUTHAP"
+    echo "After authorizing the app, grab the \`code\` parameter and slam it in here:"
+    echo -n " -> "
+    read tdcode
+    curl --silent \
+         --request POST \
+         --header "Content-Type: application/x-www-form-urlencoded" \
+         --data "grant_type=authorization_code&refresh_token=&access_type=offline&code=${tdcode}&client_id=${TD_CONSUMER_KEY}&redirect_uri=$(uriencode $TD_REDIRECT_URI)" \
+         "https://api.tdameritrade.com/v1/oauth2/token" > td_auth_refresh_info.json
+}
+
+refresh_auth() {
+    refresh_token=$(uriencode $(jq -r '.refresh_token' td_auth_refresh_info.json))
+    curl --silent \
+         --request POST \
+         --header "Content-Type: application/x-www-form-urlencoded" \
+         --data "grant_type=refresh_token&refresh_token=${refresh_token}&access_type=&code=&client_id=${TD_CONSUMER_KEY}&redirect_uri=" \
+         "https://api.tdameritrade.com/v1/oauth2/token" > td_auth_info.json
+    access_token=$(jq -j '.access_token' td_auth_info.json)
+    echo "Authorization info stored in td_auth_info.json"
+    echo "Your access token is: $access_token"
+}
+
+[[ -r td_auth_refresh_info.json ]] || get_new_auth
+refresh_auth

--- a/get_td_token.sh
+++ b/get_td_token.sh
@@ -27,7 +27,7 @@ uridecode() {
 }
 
 get_new_auth() {
-    xdg-open "https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=$(uriencode $TD_REDIRECT_URI)&client_id=$(uriencode $TD_CONSUMER_KEY)%40AMER.OAUTHAP"
+    xdg-open "https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=$(uriencode $TD_REDIRECT_URI)&client_id=$(uriencode $TD_CONSUMER_KEY)%40AMER.OAUTHAP&scope=AccountAccess"
     echo "After authorizing the app, grab the \`code\` parameter and slam it in here:"
     echo -n " -> "
     read tdcode

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -155,7 +155,7 @@ func getTDLots(config Config, client resty.Client) []Lot {
 		SetDoNotParseResponse(true).
 		Get(url)
 	if res.StatusCode() != 200 {
-		fmt.Println("Syncing TD positions failed:", res)
+		fmt.Println("Syncing TD positions failed during API request:", res)
 		return nil
 	}
 	// the API returns a top-level array so resty's auto-unmarshalling
@@ -164,11 +164,15 @@ func getTDLots(config Config, client resty.Client) []Lot {
 	defer rawBody.Close()
 	body, err := ioutil.ReadAll(res.RawBody())
 	if err != nil {
-		fmt.Println("Syncint TD positions failed:", err)
+		fmt.Println("Syncint TD positions failed while reading API response:", err)
 		return nil
 	}
 	accounts := make([]TDAccount, 0)
-	json.Unmarshal(body, &accounts)
+	err = json.Unmarshal(body, &accounts)
+	if err != nil {
+		fmt.Println("Syncing TD positions failed while parsing API response:", err)
+		return nil
+	}
 	lots := make([]Lot, 0)
 	for _, account := range accounts {
 		for _, position := range account.SecuritiesAccount.Positions {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -11,17 +11,18 @@ type Context struct {
 }
 
 type Config struct {
-	RefreshInterval       int      `yaml:"interval"`
-	Watchlist             []string `yaml:"watchlist"`
-	Lots                  []Lot    `yaml:"lots"`
-	Separate              bool     `yaml:"show-separator"`
-	ExtraInfoExchange     bool     `yaml:"show-tags"`
-	ExtraInfoFundamentals bool     `yaml:"show-fundamentals"`
-	ShowSummary           bool     `yaml:"show-summary"`
-	ShowHoldings          bool     `yaml:"show-holdings"`
-	Proxy                 string   `yaml:"proxy"`
-	Sort                  string   `yaml:"sort"`
-	Currency              string   `yaml:"currency"`
+	RefreshInterval       int        `yaml:"interval"`
+	Watchlist             []string   `yaml:"watchlist"`
+	Lots                  []Lot      `yaml:"lots"`
+	Separate              bool       `yaml:"show-separator"`
+	ExtraInfoExchange     bool       `yaml:"show-tags"`
+	ExtraInfoFundamentals bool       `yaml:"show-fundamentals"`
+	ShowSummary           bool       `yaml:"show-summary"`
+	ShowHoldings          bool       `yaml:"show-holdings"`
+	Proxy                 string     `yaml:"proxy"`
+	Sort                  string     `yaml:"sort"`
+	Currency              string     `yaml:"currency"`
+	BrokerPositionsSync   BrokerSync `yaml:"broker-positions-sync"`
 }
 
 type Reference struct {
@@ -37,6 +38,14 @@ type Lot struct {
 	Symbol   string  `yaml:"symbol"`
 	UnitCost float64 `yaml:"unit_cost"`
 	Quantity float64 `yaml:"quantity"`
+}
+
+type BrokerSync struct {
+	TD BrokerTD `yaml:"td"`
+}
+
+type BrokerTD struct {
+	AccessToken string `yaml:"access-token"`
 }
 
 type CurrencyRates map[string]CurrencyRate


### PR DESCRIPTION
This patch introduces a new config option, `broker-positions-sync`, which specifies broker authentication details in order to sync your positions from your broker automatically.

Currently only TD Ameritrade is supported.

Example:

    # ~/.ticker.yaml
    broker-positions-sync:
      td:
        access-token: "<your_token_here>"

You can get an access token manually with these instructions [1] or with
the `get_td_token.sh` example script in this patch.

Fixes #115

[1] https://developer.tdameritrade.com/content/simple-auth-local-apps

---

This is currently a proof of concept. It's working as is but I've left it as a DRAFT for some additional cleanup if you're interested in merging this feature. The cleanup I'd still like to do is:

- [ ] Move the broker API stuff into a separate file and make it more generic so that other APIs can be easily added.
- [ ] Handle initial oauth token grant as well as token refreshing.
    - Have to decide how we want to handle SSL (see discussion on #115). Options on the table are (1) self-signed cert, or (2) secure tunnel (`ngrok` or similar). I'm leaning towards (2)...
    - Once this is done I'd also be able to rip out `get_td_token.sh`.

But I don't want to do that cleanup work unless you think this feature is worth including in `ticker`. Thanks for taking a look!