### PR TITLE
Add adaptive precision for values

### DIFF
--- a/internal/ui/component/summary/summary_test.go
+++ b/internal/ui/component/summary/summary_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Summary", func() {
 				DayChangePercent: 10.0,
 			}
 			Expect(removeFormatting(m.View())).To(Equal(strings.Join([]string{
-				"Day: ↑ 100.00 (10.00%) • Change: ↑ 9000.00 (1000.00%) • Value: 10000.00",
+				"Day: ↑ 100.00 (10.000%) • Change: ↑ 9000.00 (1000.00%) • Value: 10000.00",
 				"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
 			}, "\n")))
 		})
@@ -47,7 +47,7 @@ var _ = Describe("Summary", func() {
 				DayChangePercent: -10.0,
 			}
 			Expect(removeFormatting(m.View())).To(Equal(strings.Join([]string{
-				"Day: ↓ -100.00 (-10.00%) • Change: ↓ -9000.00 (-1000.00%) • Value: 1000.00",
+				"Day: ↓ -100.00 (-10.000%) • Change: ↓ -9000.00 (-1000.00%) • Value: 1000.00",
 				"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
 			}, "\n")))
 		})
@@ -57,7 +57,7 @@ var _ = Describe("Summary", func() {
 		It("should render an empty summary", func() {
 			m := NewModel()
 			Expect(removeFormatting(m.View())).To(Equal(strings.Join([]string{
-				"Day: 0.00 (0.00%) • Change: 0.00 (0.00%) • Value: ",
+				"Day: 0.0000 (0.0000%) • Change: 0.0000 (0.0000%) • Value: ",
 				"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
 			}, "\n")))
 		})

--- a/internal/ui/component/watchlist/watchlist_test.go
+++ b/internal/ui/component/watchlist/watchlist_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Watchlist", func() {
 			0.05,
 			Position{},
 			strings.Join([]string{
-				"AAPL                       ●                                                1.05",
-				"Apple Inc.                                                       ↑ 0.05  (0.05%)",
+				"AAPL                       ●                                              1.0500",
+				"Apple Inc.                                                   ↑ 0.0500  (0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -82,8 +82,8 @@ var _ = Describe("Watchlist", func() {
 			-0.05,
 			Position{},
 			strings.Join([]string{
-				"AAPL                       ●                                                0.95",
-				"Apple Inc.                                                      ↓ -0.05 (-0.05%)",
+				"AAPL                       ●                                              0.9500",
+				"Apple Inc.                                                  ↓ -0.0500 (-0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -94,8 +94,8 @@ var _ = Describe("Watchlist", func() {
 			0.05,
 			Position{},
 			strings.Join([]string{
-				"AAPL                       ○                                                1.05",
-				"Apple Inc.                                                       ↑ 0.05  (0.05%)",
+				"AAPL                       ○                                              1.0500",
+				"Apple Inc.                                                   ↑ 0.0500  (0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -117,8 +117,8 @@ var _ = Describe("Watchlist", func() {
 				TotalChangePercent: 110.0,
 			},
 			strings.Join([]string{
-				"AAPL                       ●                     105.00                     1.05",
-				"Apple Inc.                           ↑ 55.00  (110.00%)          ↑ 0.05  (0.05%)",
+				"AAPL                       ●                     105.00                   1.0500",
+				"Apple Inc.                          ↑ 55.000  (110.00%)      ↑ 0.0500  (0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -140,8 +140,8 @@ var _ = Describe("Watchlist", func() {
 				TotalChangePercent: -30.0,
 			},
 			strings.Join([]string{
-				"AAPL                       ●                     105.00                     1.05",
-				"Apple Inc.                           ↓ -45.00 (-30.00%)          ↑ 0.05  (0.05%)",
+				"AAPL                       ●                     105.00                   1.0500",
+				"Apple Inc.                         ↓ -45.000 (-30.000%)      ↑ 0.0500  (0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -163,8 +163,8 @@ var _ = Describe("Watchlist", func() {
 				TotalChangePercent: 90.0,
 			},
 			strings.Join([]string{
-				"AAPL                       ●                      95.00                     0.95",
-				"Apple Inc.                            ↑ 45.00  (90.00%)         ↓ -0.05 (-0.05%)",
+				"AAPL                       ●                     95.000                   0.9500",
+				"Apple Inc.                          ↑ 45.000  (90.000%)     ↓ -0.0500 (-0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -186,8 +186,8 @@ var _ = Describe("Watchlist", func() {
 				TotalChangePercent: -36.67,
 			},
 			strings.Join([]string{
-				"AAPL                       ●                      95.00                     0.95",
-				"Apple Inc.                           ↓ -55.00 (-36.67%)         ↓ -0.05 (-0.05%)",
+				"AAPL                       ●                     95.000                   0.9500",
+				"Apple Inc.                         ↓ -55.000 (-36.670%)     ↓ -0.0500 (-0.0500%)",
 				"",
 			}, "\n"),
 		),
@@ -207,8 +207,8 @@ var _ = Describe("Watchlist", func() {
 				DayChangePercent: 0.0,
 			},
 			strings.Join([]string{
-				"AAPL                                              95.00                     1.00",
-				"Apple Inc.                                                         0.00  (0.00%)",
+				"AAPL                                             95.000                   1.0000",
+				"Apple Inc.                                                     0.0000  (0.0000%)",
 				"",
 			}, "\n"),
 		),
@@ -274,13 +274,13 @@ var _ = Describe("Watchlist", func() {
 			}
 			expected := strings.Join([]string{
 				"BTC-USD                    ●                                            50000.00",
-				"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+				"Bitcoin                                                    ↑ 10000.00  (20.000%)",
 				"TW                         ○                                              109.04",
-				"ThoughtWorks                                                     ↑ 3.53  (5.65%)",
+				"ThoughtWorks                                                 ↑ 3.5300  (5.6500%)",
 				"GOOG                       ○                                             2523.53",
-				"Google Inc.                                                    ↓ -32.02 (-1.35%)",
-				"AAPL                                                                        1.05",
-				"Apple Inc.                                                         0.00  (0.00%)",
+				"Google Inc.                                                 ↓ -32.020 (-1.3500%)",
+				"AAPL                                                                      1.0500",
+				"Apple Inc.                                                     0.0000  (0.0000%)",
 				"",
 			}, "\n")
 			Expect(removeFormatting(m.View())).To(Equal(expected))
@@ -334,13 +334,13 @@ var _ = Describe("Watchlist", func() {
 				}
 				expected := strings.Join([]string{
 					"BTC-USD                    ●                                            50000.00",
-					"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+					"Bitcoin                                                    ↑ 10000.00  (20.000%)",
 					"────────────────────────────────────────────────────────────────────────────────",
 					"TW                         ○                                              109.04",
-					"ThoughtWorks                                                     ↑ 3.53  (5.65%)",
+					"ThoughtWorks                                                 ↑ 3.5300  (5.6500%)",
 					"────────────────────────────────────────────────────────────────────────────────",
 					"GOOG                       ○                                             2523.53",
-					"Google Inc.                                                    ↓ -32.02 (-1.35%)",
+					"Google Inc.                                                 ↓ -32.020 (-1.3500%)",
 					"",
 				}, "\n")
 				Expect(removeFormatting(m.View())).To(Equal(expected))
@@ -376,7 +376,7 @@ var _ = Describe("Watchlist", func() {
 			}
 			expected := strings.Join([]string{
 				"BTC-USD                    ●                                            50000.00",
-				"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+				"Bitcoin                                                    ↑ 10000.00  (20.000%)",
 				"                                               USD   Real-Time   Cryptocurrency ",
 				"",
 			}, "\n")
@@ -411,7 +411,7 @@ var _ = Describe("Watchlist", func() {
 				}
 				expected := strings.Join([]string{
 					"BTC-USD                    ●                                            50000.00",
-					"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+					"Bitcoin                                                    ↑ 10000.00  (20.000%)",
 					"                                           USD   Delayed 15min   Cryptocurrency ",
 					"",
 				}, "\n")
@@ -446,7 +446,7 @@ var _ = Describe("Watchlist", func() {
 				m.Context.Config.Currency = "EUR"
 				expected := strings.Join([]string{
 					"APPL                       ●                                             5000.00",
-					"Apple, Inc                                                   ↑ 1000.00  (20.00%)",
+					"Apple, Inc                                                  ↑ 1000.00  (20.000%)",
 					"                                                 USD → EUR   Real-Time   NASDAQ ",
 					"",
 				}, "\n")
@@ -488,7 +488,7 @@ var _ = Describe("Watchlist", func() {
 			}
 			expected := strings.Join([]string{
 				"BTC-USD                    ●                                            50000.00",
-				"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+				"Bitcoin                                                    ↑ 10000.00  (20.000%)",
 				"Day Range: 10000.00 - 10000.00   Prev Close:   10000.00         Open:   10000.00",
 				"",
 			}, "\n")
@@ -524,7 +524,7 @@ var _ = Describe("Watchlist", func() {
 				}
 				expected := strings.Join([]string{
 					"BTC-USD                    ●                                            50000.00",
-					"Bitcoin                                                     ↑ 10000.00  (20.00%)",
+					"Bitcoin                                                    ↑ 10000.00  (20.000%)",
 					"                                 Prev Close:   10000.00         Open:   10000.00",
 					"",
 				}, "\n")
@@ -570,8 +570,8 @@ var _ = Describe("Watchlist", func() {
 			}
 			expected := strings.Join([]string{
 				"PTON                       ●                     105.00                   100.00",
-				"Peloton                              ↑ 55.00  (110.00%)        ↑ 10.00  (10.00%)",
-				"               Weight:   0.00%    Avg. Cost:       0.00     Quantity:     100.00",
+				"Peloton                             ↑ 55.000  (110.00%)      ↑ 10.000  (10.000%)",
+				"               Weight: 0.0000%    Avg. Cost:     0.0000     Quantity:     100.00",
 				"",
 			}, "\n")
 			Expect(removeFormatting(m.View())).To(Equal(expected))

--- a/internal/ui/util/format.go
+++ b/internal/ui/util/format.go
@@ -4,9 +4,9 @@ import "strconv"
 
 func ConvertFloatToString(f float64) string {
 	var prec = 2
-	if f < 10 {
+	if f < 10 && f > -10 {
 		prec = 4
-	} else if f < 100 {
+	} else if f < 100 && f > -100 {
 		prec = 3
 	}
 

--- a/internal/ui/util/format.go
+++ b/internal/ui/util/format.go
@@ -3,7 +3,14 @@ package util
 import "strconv"
 
 func ConvertFloatToString(f float64) string {
-	return strconv.FormatFloat(f, 'f', 2, 64)
+	var prec = 2
+	if f < 10 {
+		prec = 4
+	} else if f < 100 {
+		prec = 3
+	}
+
+	return strconv.FormatFloat(f, 'f', prec, 64)
 }
 
 func ValueText(value float64) string {

--- a/internal/ui/util/util_test.go
+++ b/internal/ui/util/util_test.go
@@ -9,9 +9,17 @@ import (
 
 var _ = Describe("Util", func() {
 	Describe("ConvertFloatToString", func() {
-		It("should convert a float to a string with a precision of two", func() {
+		It("should convert a float that smaller than 10 to a string with a precision of four", func() {
+			output := ConvertFloatToString(0.563412)
+			Expect(output).To(Equal("0.5634"))
+		})
+		It("should convert a float that between 10 and 100 to a string with a precision of three", func() {
 			output := ConvertFloatToString(12.5634)
-			Expect(output).To(Equal("12.56"))
+			Expect(output).To(Equal("12.563"))
+		})
+		It("should convert a float that greater than 100 to a string with a precision of two", func() {
+			output := ConvertFloatToString(204.4325)
+			Expect(output).To(Equal("204.43"))
 		})
 	})
 	Describe("ValueText", func() {


### PR DESCRIPTION
Number of the digits after the decimal point isn't enough especially for cryptocurrencies.

In this PR,  we decide it for each stock adaptively. Yahoo Finance shows max 4 digits min 2 digits after dot.
```
       stock < 10       --->   precision: 4     i.e.: 0.4375, 1.5436
 10 <= stock < 100      --->   precision: 3     i.e.: 10.543
100 <= stock            --->   precision: 2     i.e.: 100.30, 49435.97
```

Fixes #86