### PR TITLE
Support specifying a time zone for date/time display in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3
 
+RUN apk add --no-cache tzdata
+
 ENV TERM=xterm-256color
 
 COPY ticker /ticker

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ docker run -it --rm achannarasappa/ticker
 
 Note: config file can be mounted from the host machine by using a bind mount with `-v ~/.ticker.yaml:/.ticker.yaml`
 
+If you want to specify a time zone then you can add `-e TZ=<tz-database-name>` and replace `<tz-database-name>` with a name from the [tz database time zone list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). For example, if you are in Paris:
+
+```sh
+docker run -it --rm -e TZ=Europe/Paris achannarasappa/ticker
+```
+
+
 **snap**
 ```sh
 sudo snap install ticker


### PR DESCRIPTION
When you run ticker in docker, it uses the default time zone, which is usually UTC, for displaying the day and time. This PR adds the `tzdata` package to the docker image so you can specify the time zone via an environment variable and display the day and time in your preferred time zone.