### PR TITLE
Fix display bug when not showing summary/holdings.

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -173,10 +173,10 @@ func (m Model) View() string {
 	viewSummary := ""
 
 	if m.ctx.Config.ShowSummary && m.ctx.Config.ShowHoldings {
-		viewSummary += m.summary.View()
+		viewSummary += m.summary.View() + "\n"
 	}
 
-	return viewSummary + "\n" +
+	return viewSummary +
 		m.viewport.View() + "\n" +
 		footer(m.viewport.Width, m.lastUpdateTime, m.groupSelectedName)
 


### PR DESCRIPTION
Extra newline caused view to be N+1 rows on an N-row screen, which is not handled well by bubbletea.