### PR TITLE
Fix issue #223

### DIFF
--- a/internal/quote/yahoo/quote.go
+++ b/internal/quote/yahoo/quote.go
@@ -65,7 +65,7 @@ func transformResponseQuote(responseQuote ResponseQuote) c.AssetQuote {
 		Symbol: responseQuote.Symbol,
 		Class:  assetClass,
 		Currency: c.Currency{
-			FromCurrencyCode: responseQuote.Currency,
+			FromCurrencyCode: strings.ToUpper(responseQuote.Currency),
 		},
 		QuotePrice: c.QuotePrice{
 			Price:          responseQuote.RegularMarketPrice,


### PR DESCRIPTION
Force currency code to be upper case to compensate for Yahoo improperly formatting some foreign currencies (at least GBP), which confused currency conversion.

Not sure whether the place I chose to force the upper case conversion is the best location, but it works.