### PR TITLE
Fix/holdings ignored

### DIFF
--- a/internal/asset/asset.go
+++ b/internal/asset/asset.go
@@ -105,7 +105,8 @@ func updateHoldingWeights(assets []c.Asset, holdingSummary HoldingSummary) []c.A
 
 func getHoldingFromAssetQuote(assetQuote c.AssetQuote, lotsBySymbol map[string]AggregatedLot, currencyRateByUse currency.CurrencyRateByUse) c.Holding {
 
-	if aggregatedLot, ok := lotsBySymbol[assetQuote.Symbol]; ok {
+	// fix #240: Use Asset Id in place of Symbol as unique id
+	if aggregatedLot, ok := lotsBySymbol[assetQuote.Id]; ok {
 		value := aggregatedLot.Quantity * assetQuote.QuotePrice.Price * currencyRateByUse.QuotePrice
 		cost := aggregatedLot.Cost * currencyRateByUse.PositionCost
 		totalChangeAmount := value - cost

--- a/internal/asset/asset.go
+++ b/internal/asset/asset.go
@@ -106,7 +106,7 @@ func updateHoldingWeights(assets []c.Asset, holdingSummary HoldingSummary) []c.A
 func getHoldingFromAssetQuote(assetQuote c.AssetQuote, lotsBySymbol map[string]AggregatedLot, currencyRateByUse currency.CurrencyRateByUse) c.Holding {
 
 	// fix #240: Use Asset Id in place of Symbol as unique id
-	if aggregatedLot, ok := lotsBySymbol[assetQuote.Id]; ok {
+	if aggregatedLot, ok := lotsBySymbol[assetQuote.ID]; ok {
 		value := aggregatedLot.Quantity * assetQuote.QuotePrice.Price * currencyRateByUse.QuotePrice
 		cost := aggregatedLot.Cost * currencyRateByUse.PositionCost
 		totalChangeAmount := value - cost

--- a/internal/asset/asset_fixture_test.go
+++ b/internal/asset/asset_fixture_test.go
@@ -17,6 +17,7 @@ var fixtureAssetGroupQuote = c.AssetGroupQuote{
 	},
 	AssetQuotes: []c.AssetQuote{
 		{
+			Id:       "TWKS",
 			Name:     "ThoughtWorks",
 			Symbol:   "TWKS",
 			Class:    c.AssetClassStock,
@@ -37,6 +38,7 @@ var fixtureAssetGroupQuote = c.AssetGroupQuote{
 			},
 		},
 		{
+			Id:       "MSFT",
 			Name:     "Microsoft Inc",
 			Symbol:   "MSFT",
 			Class:    c.AssetClassStock,
@@ -52,6 +54,7 @@ var fixtureAssetGroupQuote = c.AssetGroupQuote{
 			},
 		},
 		{
+			Id:       "SOL1-USD",
 			Name:     "Solana USD",
 			Symbol:   "SOL1-USD",
 			Class:    c.AssetClassCryptocurrency,

--- a/internal/asset/asset_fixture_test.go
+++ b/internal/asset/asset_fixture_test.go
@@ -17,7 +17,7 @@ var fixtureAssetGroupQuote = c.AssetGroupQuote{
 	},
 	AssetQuotes: []c.AssetQuote{
 		{
-			Id:       "TWKS",
+			ID:       "TWKS",
 			Name:     "ThoughtWorks",
 			Symbol:   "TWKS",
 			Class:    c.AssetClassStock,
@@ -38,7 +38,7 @@ var fixtureAssetGroupQuote = c.AssetGroupQuote{
 			},
 		},
 		{
-			Id:       "MSFT",
+			ID:       "MSFT",
 			Name:     "Microsoft Inc",
 			Symbol:   "MSFT",
 			Class:    c.AssetClassStock,
@@ -54,7 +54,7 @@ var fixtureAssetGroupQuote = c.AssetGroupQuote{
 			},
 		},
 		{
-			Id:       "SOL1-USD",
+			ID:       "SOL1-USD",
 			Name:     "Solana USD",
 			Symbol:   "SOL1-USD",
 			Class:    c.AssetClassCryptocurrency,

--- a/internal/asset/asset_test.go
+++ b/internal/asset/asset_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Asset", func() {
 			inputAssetGroupQuote := fixtureAssetGroupQuote
 			inputAssetGroupQuote.AssetQuotes = []c.AssetQuote{
 				{
+					Id:            "TWKS",
 					Name:          "ThoughtWorks",
 					Symbol:        "TWKS",
 					Class:         c.AssetClassStock,
@@ -110,6 +111,7 @@ var _ = Describe("Asset", func() {
 					QuoteExtended: c.QuoteExtended{FiftyTwoWeekHigh: 150, FiftyTwoWeekLow: 50, MarketCap: 1000000},
 				},
 				{
+					Id:         "MSFT",
 					Name:       "Microsoft Inc",
 					Symbol:     "MSFT",
 					Class:      c.AssetClassStock,

--- a/internal/asset/asset_test.go
+++ b/internal/asset/asset_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Asset", func() {
 			inputAssetGroupQuote := fixtureAssetGroupQuote
 			inputAssetGroupQuote.AssetQuotes = []c.AssetQuote{
 				{
-					Id:            "TWKS",
+					ID:            "TWKS",
 					Name:          "ThoughtWorks",
 					Symbol:        "TWKS",
 					Class:         c.AssetClassStock,
@@ -111,7 +111,7 @@ var _ = Describe("Asset", func() {
 					QuoteExtended: c.QuoteExtended{FiftyTwoWeekHigh: 150, FiftyTwoWeekLow: 50, MarketCap: 1000000},
 				},
 				{
-					Id:         "MSFT",
+					ID:         "MSFT",
 					Name:       "Microsoft Inc",
 					Symbol:     "MSFT",
 					Class:      c.AssetClassStock,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -349,7 +349,7 @@ func getSymbolAndSource(symbol string, tickerSymbolToSourceSymbol symbol.TickerS
 func appendSymbol(symbolsUnique map[c.QuoteSource]c.AssetGroupSymbolsBySource, symbolAndSource symbolSource) map[c.QuoteSource]c.AssetGroupSymbolsBySource {
 
 	newSymbol := c.Symbol{
-		Id:   symbolAndSource.id,
+		ID:   symbolAndSource.id,
 		Name: symbolAndSource.symbol,
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -266,20 +266,20 @@ var _ = Describe("Cli", func() {
 								}, g.Elements{
 									"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 										"Symbols": g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
-											"0": Equal("TSLA"),
+											"0": Equal(c.Symbol{Id: "TSLA", Name: "TSLA"}),
 										}),
 										"Source": Equal(c.QuoteSourceYahoo),
 									}),
 									"2": g.MatchFields(g.IgnoreExtras, g.Fields{
 										"Symbols": g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
-											"0": Equal("ethereum"),
-											"1": Equal("solana"),
+											"0": Equal(c.Symbol{Id: "ETHEREUM.CG", Name: "ethereum"}),
+											"1": Equal(c.Symbol{Id: "SOL.X", Name: "solana"}),
 										}),
 										"Source": Equal(c.QuoteSourceCoingecko),
 									}),
 									"4": g.MatchFields(g.IgnoreExtras, g.Fields{
 										"Symbols": g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
-											"0": Equal("bitcoin"),
+											"0": Equal(c.Symbol{Id: "BITCOIN.CC", Name: "bitcoin"}),
 										}),
 										"Source": Equal(c.QuoteSourceCoinCap),
 									}),

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -266,20 +266,20 @@ var _ = Describe("Cli", func() {
 								}, g.Elements{
 									"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 										"Symbols": g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
-											"0": Equal(c.Symbol{Id: "TSLA", Name: "TSLA"}),
+											"0": Equal(c.Symbol{ID: "TSLA", Name: "TSLA"}),
 										}),
 										"Source": Equal(c.QuoteSourceYahoo),
 									}),
 									"2": g.MatchFields(g.IgnoreExtras, g.Fields{
 										"Symbols": g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
-											"0": Equal(c.Symbol{Id: "ETHEREUM.CG", Name: "ethereum"}),
-											"1": Equal(c.Symbol{Id: "SOL.X", Name: "solana"}),
+											"0": Equal(c.Symbol{ID: "ETHEREUM.CG", Name: "ethereum"}),
+											"1": Equal(c.Symbol{ID: "SOL.X", Name: "solana"}),
 										}),
 										"Source": Equal(c.QuoteSourceCoingecko),
 									}),
 									"4": g.MatchFields(g.IgnoreExtras, g.Fields{
 										"Symbols": g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
-											"0": Equal(c.Symbol{Id: "BITCOIN.CC", Name: "bitcoin"}),
+											"0": Equal(c.Symbol{ID: "BITCOIN.CC", Name: "bitcoin"}),
 										}),
 										"Source": Equal(c.QuoteSourceCoinCap),
 									}),

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -53,7 +53,7 @@ type AssetGroup struct {
 }
 
 type AssetGroupSymbolsBySource struct {
-	Symbols []string
+	Symbols []Symbol
 	Source  QuoteSource
 }
 
@@ -228,4 +228,10 @@ type AssetQuote struct {
 	QuoteSource   QuoteSource
 	Exchange      Exchange
 	Meta          Meta
+}
+
+// Symbol represents a symbol but keep id not only name
+type Symbol struct {
+	Id   string
+	Name string
 }

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -218,6 +218,7 @@ const (
 
 // AssetQuote represents a price quote and related attributes for a single security
 type AssetQuote struct {
+	Id            string
 	Name          string
 	Symbol        string
 	Class         AssetClass

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -218,7 +218,7 @@ const (
 
 // AssetQuote represents a price quote and related attributes for a single security
 type AssetQuote struct {
-	Id            string
+	ID            string
 	Name          string
 	Symbol        string
 	Class         AssetClass
@@ -232,6 +232,6 @@ type AssetQuote struct {
 
 // Symbol represents a symbol but keep id not only name
 type Symbol struct {
-	Id   string
+	ID   string
 	Name string
 }

--- a/internal/common/helper.go
+++ b/internal/common/helper.go
@@ -1,0 +1,14 @@
+package common
+
+import "strings"
+
+// Concatenates symbol names
+func JoinSymbolName(symbols []Symbol, separator string) string {
+	var symbolsStr []string
+
+	for _, symbol := range symbols {
+		symbolsStr = append(symbolsStr, symbol.Name)
+	}
+
+	return strings.Join(symbolsStr, separator)
+}

--- a/internal/common/helper.go
+++ b/internal/common/helper.go
@@ -4,10 +4,10 @@ import "strings"
 
 // Concatenates symbol names
 func JoinSymbolName(symbols []Symbol, separator string) string {
-	var symbolsStr []string
+	symbolsStr := make([]string, len(symbols))
 
-	for _, symbol := range symbols {
-		symbolsStr = append(symbolsStr, symbol.Name)
+	for i, symbol := range symbols {
+		symbolsStr[i] = symbol.Name
 	}
 
 	return strings.Join(symbolsStr, separator)

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -43,11 +43,11 @@ var _ = Describe("Print", func() {
 								Source: c.QuoteSourceYahoo,
 								Symbols: []c.Symbol{
 									{
-										Id:   "GOOG",
+										ID:   "GOOG",
 										Name: "GOOG",
 									},
 									{
-										Id:   "RBLX",
+										ID:   "RBLX",
 										Name: "RBLX",
 									},
 								},

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -41,9 +41,15 @@ var _ = Describe("Print", func() {
 						SymbolsBySource: []c.AssetGroupSymbolsBySource{
 							{
 								Source: c.QuoteSourceYahoo,
-								Symbols: []string{
-									"GOOG",
-									"RBLX",
+								Symbols: []c.Symbol{
+									{
+										Id:   "GOOG",
+										Name: "GOOG",
+									},
+									{
+										Id:   "RBLX",
+										Name: "RBLX",
+									},
 								},
 							},
 						},

--- a/internal/quote/coincap/coincap_test.go
+++ b/internal/quote/coincap/coincap_test.go
@@ -16,7 +16,7 @@ var _ = Describe("CoinCap Quote", func() {
 
 			MockResponseCoincapQuotes()
 
-			output := GetAssetQuotes(*client, []string{"elrond"})
+			output := GetAssetQuotes(*client, []c.Symbol{{Id: "ELROND.CC", Name: "elrond"}})
 			Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 				"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 					"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{

--- a/internal/quote/coincap/coincap_test.go
+++ b/internal/quote/coincap/coincap_test.go
@@ -16,7 +16,7 @@ var _ = Describe("CoinCap Quote", func() {
 
 			MockResponseCoincapQuotes()
 
-			output := GetAssetQuotes(*client, []c.Symbol{{Id: "ELROND.CC", Name: "elrond"}})
+			output := GetAssetQuotes(*client, []c.Symbol{{ID: "ELROND.CC", Name: "elrond"}})
 			Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 				"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 					"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{

--- a/internal/quote/coincap/quote.go
+++ b/internal/quote/coincap/quote.go
@@ -10,6 +10,7 @@ import (
 
 // Quote represents a quote of a single security from the API response
 type Quote struct {
+	Id                         string `json:"id"`
 	ShortName                  string `json:"name"`
 	Symbol                     string `json:"symbol"`
 	RegularMarketChangePercent string `json:"changePercent24Hr"`
@@ -32,6 +33,7 @@ func transformQuote(responseQuote Quote) c.AssetQuote {
 	volume, _ := strconv.ParseFloat(responseQuote.RegularMarketVolume, 64)
 
 	assetQuote := c.AssetQuote{
+		Id:     strings.ToUpper(responseQuote.Id) + ".CC",
 		Name:   responseQuote.ShortName,
 		Symbol: responseQuote.Symbol,
 		Class:  c.AssetClassCryptocurrency,

--- a/internal/quote/coincap/quote.go
+++ b/internal/quote/coincap/quote.go
@@ -98,7 +98,13 @@ func GetAssetQuotes(client resty.Client, symbols []c.Symbol) []c.AssetQuote {
 		SetQueryParam("ids", strings.ToLower(symbolsString)).
 		Get("https://api.coincap.io/v2/assets")
 
-	data := (res.Result().(*Response)).Data
+	response, ok := res.Result().(*Response)
+
+	if !ok {
+		return []c.AssetQuote{}
+	}
+
+	data := response.Data
 
 	// fix #245 : force Id using Symbol declaration
 	for idx, quote := range data {

--- a/internal/quote/coincap/quote.go
+++ b/internal/quote/coincap/quote.go
@@ -10,7 +10,7 @@ import (
 
 // Quote represents a quote of a single security from the API response
 type Quote struct {
-	Id                         string `json:"id"`
+	ID                         string `json:"id"`
 	ShortName                  string `json:"name"`
 	Symbol                     string `json:"symbol"`
 	RegularMarketChangePercent string `json:"changePercent24Hr"`
@@ -33,7 +33,7 @@ func transformQuote(responseQuote Quote) c.AssetQuote {
 	volume, _ := strconv.ParseFloat(responseQuote.RegularMarketVolume, 64)
 
 	assetQuote := c.AssetQuote{
-		Id:     responseQuote.Id,
+		ID:     responseQuote.ID,
 		Name:   responseQuote.ShortName,
 		Symbol: responseQuote.Symbol,
 		Class:  c.AssetClassCryptocurrency,
@@ -102,7 +102,7 @@ func GetAssetQuotes(client resty.Client, symbols []c.Symbol) []c.AssetQuote {
 
 	// fix #245 : force Id using Symbol declaration
 	for idx, quote := range data {
-		data[idx].Id = symbolsDict[strings.ToUpper(quote.Id)].Id
+		data[idx].ID = symbolsDict[strings.ToUpper(quote.ID)].ID
 	}
 
 	return transformQuotes(data) //nolint:forcetypeassert

--- a/internal/quote/coingecko/coingecko.go
+++ b/internal/quote/coingecko/coingecko.go
@@ -45,7 +45,7 @@ func transformResponseToAssetQuotes(responseQuotes *ResponseQuotes) []c.AssetQuo
 	for _, responseQuote := range *responseQuotes {
 
 		assetQuote := c.AssetQuote{
-			Id:     responseQuote.Id,
+			ID:     responseQuote.Id,
 			Name:   responseQuote.Name,
 			Symbol: strings.ToUpper(responseQuote.Symbol),
 			Class:  c.AssetClassCryptocurrency,
@@ -106,7 +106,7 @@ func GetAssetQuotes(client resty.Client, symbols []c.Symbol) []c.AssetQuote {
 
 	// fix #245 : force Id using Symbol declaration
 	for idx, quote := range *out {
-		(*out)[idx].Id = symbolsDict[strings.ToUpper(quote.Id)].Id
+		(*out)[idx].Id = symbolsDict[strings.ToUpper(quote.Id)].ID
 	}
 
 	assetQuotes := transformResponseToAssetQuotes(out)

--- a/internal/quote/coingecko/coingecko.go
+++ b/internal/quote/coingecko/coingecko.go
@@ -45,6 +45,7 @@ func transformResponseToAssetQuotes(responseQuotes *ResponseQuotes) []c.AssetQuo
 	for _, responseQuote := range *responseQuotes {
 
 		assetQuote := c.AssetQuote{
+			Id:     strings.ToUpper(responseQuote.Id) + ".CG",
 			Name:   responseQuote.Name,
 			Symbol: strings.ToUpper(responseQuote.Symbol),
 			Class:  c.AssetClassCryptocurrency,

--- a/internal/quote/coingecko/coingecko_test.go
+++ b/internal/quote/coingecko/coingecko_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Coingecko", func() {
 		It("should make a request to get crypto quotes and transform the response", func() {
 			MockResponseCoingeckoQuotes()
 
-			output := GetAssetQuotes(*client, []c.Symbol{{Id: "BITCOIN.CG", Name: "bitcoin"}})
+			output := GetAssetQuotes(*client, []c.Symbol{{ID: "BITCOIN.CG", Name: "bitcoin"}})
 			Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 				"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 					"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{

--- a/internal/quote/coingecko/coingecko_test.go
+++ b/internal/quote/coingecko/coingecko_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Coingecko", func() {
 		It("should make a request to get crypto quotes and transform the response", func() {
 			MockResponseCoingeckoQuotes()
 
-			output := GetAssetQuotes(*client, []string{"bitcoin"})
+			output := GetAssetQuotes(*client, []c.Symbol{{Id: "BITCOIN.CG", Name: "bitcoin"}})
 			Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 				"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 					"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{

--- a/internal/quote/quote.go
+++ b/internal/quote/quote.go
@@ -49,7 +49,7 @@ func GetAssetGroupQuote(dep c.Dependencies) func(c.AssetGroup) c.AssetGroupQuote
 func getUniqueSymbolsBySource(assetGroups []c.AssetGroup) []c.AssetGroupSymbolsBySource {
 
 	symbols := make(map[c.QuoteSource]map[string]bool)
-	symbolsUnique := make(map[c.QuoteSource][]string)
+	symbolsUnique := make(map[c.QuoteSource][]c.Symbol)
 	assetGroupSymbolsBySource := make([]c.AssetGroupSymbolsBySource, 0)
 	for _, assetGroup := range assetGroups {
 
@@ -63,8 +63,8 @@ func getUniqueSymbolsBySource(assetGroups []c.AssetGroup) []c.AssetGroupSymbolsB
 					symbols[source] = map[string]bool{}
 				}
 
-				if !symbols[source][symbol] {
-					symbols[source][symbol] = true
+				if !symbols[source][symbol.Name] {
+					symbols[source][symbol.Name] = true
 					symbolsUnique[source] = append(symbolsUnique[source], symbol)
 				}
 			}

--- a/internal/quote/quote_test.go
+++ b/internal/quote/quote_test.go
@@ -89,28 +89,28 @@ var _ = Describe("Quote", func() {
 				SymbolsBySource: []c.AssetGroupSymbolsBySource{
 					{
 						Source: c.QuoteSourceYahoo,
-						Symbols: []string{
-							"GOOG",
-							"RBLX",
+						Symbols: []c.Symbol{
+							{Id: "GOOG", Name: "GOOG"},
+							{Id: "RBLX", Name: "RBLX"},
 						},
 					},
 					{
 						Source: c.QuoteSourceCoingecko,
-						Symbols: []string{
-							"bitcoin",
+						Symbols: []c.Symbol{
+							{Id: "BITCOIN.CG", Name: "bitcoin"},
 						},
 					},
 					{
 						Source: c.QuoteSourceCoinCap,
-						Symbols: []string{
-							"elrond",
+						Symbols: []c.Symbol{
+							{Id: "ELROND.CC", Name: "elrond"},
 						},
 					},
 					{
 						Source: c.QuoteSourceUserDefined,
-						Symbols: []string{
-							"CASH",
-							"PRIVATESHARES",
+						Symbols: []c.Symbol{
+							{Id: "CASH", Name: "CASH"},
+							{Id: "PRIVATESHARES", Name: "PRIVATESHARES"},
 						},
 					},
 				},
@@ -148,8 +148,8 @@ var _ = Describe("Quote", func() {
 					SymbolsBySource: []c.AssetGroupSymbolsBySource{
 						{
 							Source: c.QuoteSourceYahoo,
-							Symbols: []string{
-								"GOOG",
+							Symbols: []c.Symbol{
+								{Id: "GOOG", Name: "GOOG"},
 							},
 						},
 					},

--- a/internal/quote/quote_test.go
+++ b/internal/quote/quote_test.go
@@ -90,27 +90,27 @@ var _ = Describe("Quote", func() {
 					{
 						Source: c.QuoteSourceYahoo,
 						Symbols: []c.Symbol{
-							{Id: "GOOG", Name: "GOOG"},
-							{Id: "RBLX", Name: "RBLX"},
+							{ID: "GOOG", Name: "GOOG"},
+							{ID: "RBLX", Name: "RBLX"},
 						},
 					},
 					{
 						Source: c.QuoteSourceCoingecko,
 						Symbols: []c.Symbol{
-							{Id: "BITCOIN.CG", Name: "bitcoin"},
+							{ID: "BITCOIN.CG", Name: "bitcoin"},
 						},
 					},
 					{
 						Source: c.QuoteSourceCoinCap,
 						Symbols: []c.Symbol{
-							{Id: "ELROND.CC", Name: "elrond"},
+							{ID: "ELROND.CC", Name: "elrond"},
 						},
 					},
 					{
 						Source: c.QuoteSourceUserDefined,
 						Symbols: []c.Symbol{
-							{Id: "CASH", Name: "CASH"},
-							{Id: "PRIVATESHARES", Name: "PRIVATESHARES"},
+							{ID: "CASH", Name: "CASH"},
+							{ID: "PRIVATESHARES", Name: "PRIVATESHARES"},
 						},
 					},
 				},
@@ -149,7 +149,7 @@ var _ = Describe("Quote", func() {
 						{
 							Source: c.QuoteSourceYahoo,
 							Symbols: []c.Symbol{
-								{Id: "GOOG", Name: "GOOG"},
+								{ID: "GOOG", Name: "GOOG"},
 							},
 						},
 					},

--- a/internal/quote/yahoo/currency.go
+++ b/internal/quote/yahoo/currency.go
@@ -72,9 +72,9 @@ func transformResponseCurrencyPairs(responseQuotes []ResponseQuote, targetCurren
 
 }
 
-func getCurrencyPairSymbols(client resty.Client, symbols []string, targetCurrency string) ([]string, error) {
+func getCurrencyPairSymbols(client resty.Client, symbols []c.Symbol, targetCurrency string) ([]string, error) {
 
-	symbolsString := strings.Join(symbols, ",")
+	symbolsString := c.JoinSymbolName(symbols, ",")
 
 	res, err := client.R().
 		SetResult(Response{}).
@@ -90,7 +90,7 @@ func getCurrencyPairSymbols(client resty.Client, symbols []string, targetCurrenc
 }
 
 // GetCurrencyRates retrieves the currency rates to convert from each currency for the given symbols to the target currency
-func GetCurrencyRates(client resty.Client, symbols []string, targetCurrency string) (c.CurrencyRates, error) {
+func GetCurrencyRates(client resty.Client, symbols []c.Symbol, targetCurrency string) (c.CurrencyRates, error) {
 
 	if targetCurrency == "" {
 		targetCurrency = "USD"

--- a/internal/quote/yahoo/quote.go
+++ b/internal/quote/yahoo/quote.go
@@ -191,7 +191,12 @@ func GetAssetQuotes(client resty.Client, symbols []c.Symbol) func() []c.AssetQuo
 			SetQueryParam("symbols", symbolsString).
 			Get("/v7/finance/quote")
 
-		var quotes = (res.Result().(*Response)).QuoteResponse.Quotes
+		var response, ok = res.Result().(*Response)
+		if !ok {
+			return []c.AssetQuote{}
+		}
+
+		var quotes = response.QuoteResponse.Quotes
 
 		// fix #245 : force Id using Symbol declaration
 		for idx, quote := range quotes {
@@ -199,5 +204,6 @@ func GetAssetQuotes(client resty.Client, symbols []c.Symbol) func() []c.AssetQuo
 		}
 
 		return transformResponseQuotes(quotes) //nolint:forcetypeassert
+
 	}
 }

--- a/internal/quote/yahoo/quote.go
+++ b/internal/quote/yahoo/quote.go
@@ -75,6 +75,7 @@ func transformResponseQuote(responseQuote ResponseQuote) c.AssetQuote {
 	isVariablePrecision := (assetClass == c.AssetClassCryptocurrency)
 
 	assetQuote := c.AssetQuote{
+		Id:     responseQuote.Symbol,
 		Name:   responseQuote.ShortName,
 		Symbol: responseQuote.Symbol,
 		Class:  assetClass,

--- a/internal/quote/yahoo/quote.go
+++ b/internal/quote/yahoo/quote.go
@@ -14,7 +14,7 @@ var (
 
 // ResponseQuote represents a quote of a single security from the API response
 type ResponseQuote struct {
-	Id                         string
+	ID                         string
 	ShortName                  string              `json:"shortName"`
 	Symbol                     string              `json:"symbol"`
 	MarketState                string              `json:"marketState"`
@@ -76,7 +76,7 @@ func transformResponseQuote(responseQuote ResponseQuote) c.AssetQuote {
 	isVariablePrecision := (assetClass == c.AssetClassCryptocurrency)
 
 	assetQuote := c.AssetQuote{
-		Id:     responseQuote.Id,
+		ID:     responseQuote.ID,
 		Name:   responseQuote.ShortName,
 		Symbol: responseQuote.Symbol,
 		Class:  assetClass,
@@ -195,7 +195,7 @@ func GetAssetQuotes(client resty.Client, symbols []c.Symbol) func() []c.AssetQuo
 
 		// fix #245 : force Id using Symbol declaration
 		for idx, quote := range quotes {
-			quotes[idx].Id = symbolsDict[strings.ToUpper(quote.Symbol)].Id
+			quotes[idx].ID = symbolsDict[strings.ToUpper(quote.Symbol)].ID
 		}
 
 		return transformResponseQuotes(quotes) //nolint:forcetypeassert

--- a/internal/quote/yahoo/yahoo_test.go
+++ b/internal/quote/yahoo/yahoo_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Yahoo Quote", func() {
 				return resp, nil
 			})
 
-			output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+			output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 			Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 				"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 					"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -96,7 +96,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+				output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -136,7 +136,7 @@ var _ = Describe("Yahoo Quote", func() {
 						return resp, nil
 					})
 
-					output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+					output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 					Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 						"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 							"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -181,7 +181,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+				output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -223,7 +223,7 @@ var _ = Describe("Yahoo Quote", func() {
 						return resp, nil
 					})
 
-					output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+					output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 					Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 						"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 							"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -263,7 +263,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+				output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -308,7 +308,7 @@ var _ = Describe("Yahoo Quote", func() {
 						return resp, nil
 					})
 
-					output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
+					output := GetAssetQuotes(*client, []c.Symbol{{ID: "NET", Name: "NET"}})()
 					Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 						"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 							"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -354,7 +354,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []c.Symbol{{Id: "BTC-USD", Name: "BTC-USD"}})()
+				output := GetAssetQuotes(*client, []c.Symbol{{ID: "BTC-USD", Name: "BTC-USD"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"Class": Equal(c.AssetClassCryptocurrency),
@@ -369,7 +369,7 @@ var _ = Describe("Yahoo Quote", func() {
 
 			MockResponse(ResponseParameters{Symbol: "VOW3.DE", Currency: "EUR", Price: 0.0})
 			MockResponse(ResponseParameters{Symbol: "EURUSD%3DX", Currency: "USD", Price: 1.2})
-			output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "USD")
+			output, err := GetCurrencyRates(*client, []c.Symbol{{ID: "VOW3.DE", Name: "VOW3.DE"}}, "USD")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(Equal(c.CurrencyRates{
 				"EUR": c.CurrencyRate{
@@ -386,7 +386,7 @@ var _ = Describe("Yahoo Quote", func() {
 
 				MockResponse(ResponseParameters{Symbol: "VOW3.DE", Currency: "EUR", Price: 0.0})
 				MockResponse(ResponseParameters{Symbol: "EURUSD%3DX", Currency: "USD", Price: 1.2})
-				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{ID: "VOW3.DE", Name: "VOW3.DE"}}, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{
 					"EUR": c.CurrencyRate{
@@ -403,7 +403,7 @@ var _ = Describe("Yahoo Quote", func() {
 			It("returns an empty currency exchange rate list", func() {
 
 				MockResponse(ResponseParameters{Symbol: "VOW3.DE", Currency: "EUR", Price: 0.0})
-				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{ID: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 
@@ -431,7 +431,7 @@ var _ = Describe("Yahoo Quote", func() {
 					resp.Header.Set("Content-Type", "application/json")
 					return resp, nil
 				})
-				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{ID: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
 				Expect(err).To(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 
@@ -458,7 +458,7 @@ var _ = Describe("Yahoo Quote", func() {
 					resp.Header.Set("Content-Type", "application/json")
 					return resp, nil
 				})
-				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{ID: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 
@@ -486,7 +486,7 @@ var _ = Describe("Yahoo Quote", func() {
 					resp.Header.Set("Content-Type", "application/json")
 					return resp, nil
 				})
-				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "USD")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{ID: "VOW3.DE", Name: "VOW3.DE"}}, "USD")
 				Expect(err).To(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 

--- a/internal/quote/yahoo/yahoo_test.go
+++ b/internal/quote/yahoo/yahoo_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Yahoo Quote", func() {
 				return resp, nil
 			})
 
-			output := GetAssetQuotes(*client, []string{"NET"})()
+			output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 			Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 				"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 					"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -96,7 +96,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []string{"NET"})()
+				output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -136,7 +136,7 @@ var _ = Describe("Yahoo Quote", func() {
 						return resp, nil
 					})
 
-					output := GetAssetQuotes(*client, []string{"NET"})()
+					output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 					Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 						"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 							"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -181,7 +181,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []string{"NET"})()
+				output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -223,7 +223,7 @@ var _ = Describe("Yahoo Quote", func() {
 						return resp, nil
 					})
 
-					output := GetAssetQuotes(*client, []string{"NET"})()
+					output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 					Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 						"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 							"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -263,7 +263,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []string{"NET"})()
+				output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -308,7 +308,7 @@ var _ = Describe("Yahoo Quote", func() {
 						return resp, nil
 					})
 
-					output := GetAssetQuotes(*client, []string{"NET"})()
+					output := GetAssetQuotes(*client, []c.Symbol{{Id: "NET", Name: "NET"}})()
 					Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 						"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 							"QuotePrice": g.MatchFields(g.IgnoreExtras, g.Fields{
@@ -354,7 +354,7 @@ var _ = Describe("Yahoo Quote", func() {
 					return resp, nil
 				})
 
-				output := GetAssetQuotes(*client, []string{"BTC-USD"})()
+				output := GetAssetQuotes(*client, []c.Symbol{{Id: "BTC-USD", Name: "BTC-USD"}})()
 				Expect(output).To(g.MatchAllElementsWithIndex(g.IndexIdentity, g.Elements{
 					"0": g.MatchFields(g.IgnoreExtras, g.Fields{
 						"Class": Equal(c.AssetClassCryptocurrency),
@@ -369,7 +369,7 @@ var _ = Describe("Yahoo Quote", func() {
 
 			MockResponse(ResponseParameters{Symbol: "VOW3.DE", Currency: "EUR", Price: 0.0})
 			MockResponse(ResponseParameters{Symbol: "EURUSD%3DX", Currency: "USD", Price: 1.2})
-			output, err := GetCurrencyRates(*client, []string{"VOW3.DE"}, "USD")
+			output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "USD")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(Equal(c.CurrencyRates{
 				"EUR": c.CurrencyRate{
@@ -386,7 +386,7 @@ var _ = Describe("Yahoo Quote", func() {
 
 				MockResponse(ResponseParameters{Symbol: "VOW3.DE", Currency: "EUR", Price: 0.0})
 				MockResponse(ResponseParameters{Symbol: "EURUSD%3DX", Currency: "USD", Price: 1.2})
-				output, err := GetCurrencyRates(*client, []string{"VOW3.DE"}, "")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{
 					"EUR": c.CurrencyRate{
@@ -403,7 +403,7 @@ var _ = Describe("Yahoo Quote", func() {
 			It("returns an empty currency exchange rate list", func() {
 
 				MockResponse(ResponseParameters{Symbol: "VOW3.DE", Currency: "EUR", Price: 0.0})
-				output, err := GetCurrencyRates(*client, []string{"VOW3.DE"}, "EUR")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 
@@ -431,7 +431,7 @@ var _ = Describe("Yahoo Quote", func() {
 					resp.Header.Set("Content-Type", "application/json")
 					return resp, nil
 				})
-				output, err := GetCurrencyRates(*client, []string{"VOW3.DE"}, "EUR")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
 				Expect(err).To(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 
@@ -458,7 +458,7 @@ var _ = Describe("Yahoo Quote", func() {
 					resp.Header.Set("Content-Type", "application/json")
 					return resp, nil
 				})
-				output, err := GetCurrencyRates(*client, []string{"VOW3.DE"}, "EUR")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "EUR")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 
@@ -486,7 +486,7 @@ var _ = Describe("Yahoo Quote", func() {
 					resp.Header.Set("Content-Type", "application/json")
 					return resp, nil
 				})
-				output, err := GetCurrencyRates(*client, []string{"VOW3.DE"}, "USD")
+				output, err := GetCurrencyRates(*client, []c.Symbol{{Id: "VOW3.DE", Name: "VOW3.DE"}}, "USD")
 				Expect(err).To(HaveOccurred())
 				Expect(output).To(Equal(c.CurrencyRates{}))
 


### PR DESCRIPTION
Hi there,

As a fix to achannarasappa#245 issue and by extension to every sources which is not Yahoo! source, I propose this MR. 

Looks like the holdings appear only in Yahoo! source because the key to look-for "holdings" in yaml-config-file variables is based on Symbol. 
In Yahoo! source, the symbol is the id and Yahoo! API returns the same value as symbol. This is different with the other source where the symbol id to search on the API could be "cardona" and the symbol "ADA" (which is different to CARDONA.CG).

As proposed solution, I had an "Id" into AssetQuote as an equivalent to the "Symbol" value in Yaml config file and I provisioned this value from the "Symbol" declaration into the config file (I used a new c.Symbol type with "id" and "name"). 

I hope it could help to fix this issue.