### PR TITLE
Adds feature for printing holding summary in commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,25 @@ $ ticker --config=./.ticker.yaml print
 * Ensure there is at least one lot in the configuration file in order to generate output
 * A specific config file can be specified with the `--config` flag
 
+#### Printing Holdings Summary
+
+Use the `--summary` flag for printing the holding summary, showing day change, total change, value and cost of portfolio.
+
+```sh
+$ ticker --config=./.ticker.yaml print --summary
+Day change:	  -192.30 (-1.05%)
+Total change:	-13296.86 (-42.06%)
+Value:		    18315.27
+Cost:		      31612.13
+```
+
+The output is easily parseable using `awk`:
+
+```sh
+$ ticker --config=./.ticker.yaml print --summary | awk '/Value/{print $2}'
+18315.27
+```
+
 ## Notes
 
 * **Real-time quotes** - Quotes are pulled from Yahoo finance which may provide delayed stock quotes depending on the exchange. The major US exchanges (NYSE, NASDAQ) have real-time quotes however other exchanges may not. Consult the [help article](https://help.yahoo.com/kb/SLN2310.html) on exchange delays to determine which exchanges you can expect delays for or use the `--show-tags` flag to include timeliness of data alongside quotes in `ticker`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,13 +38,6 @@ var (
 		Args:   cli.Validate(&config, &options, &err),
 		Run:    print.Run(&dep, &ctx, &optionsPrint),
 	}
-	printSummaryCmd = &cobra.Command{
-		Use:    "print-summary",
-		Short:  "Prints holdings summary",
-		PreRun: initContext,
-		Args:   cli.Validate(&config, &options, &err),
-		Run:    print.RunSummary(&dep, &ctx, &optionsPrint),
-	}
 )
 
 // Execute starts the CLI or prints an error is there is one
@@ -68,7 +61,7 @@ func init() { //nolint: gochecknoinits
 	rootCmd.Flags().StringVar(&options.Proxy, "proxy", "", "proxy URL for requests (default is none)")
 	rootCmd.Flags().StringVar(&options.Sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. Set \"value\" to sort by position value. Keep empty to sort according to change percent")
 	rootCmd.AddCommand(printCmd)
-	rootCmd.AddCommand(printSummaryCmd)
+	printCmd.Flags().BoolVar(&optionsPrint.Summary, "summary", false, "prints holdings summary (day change, total change, value, cost)")
 	printCmd.Flags().StringVar(&optionsPrint.Format, "format", "", "output format for printing holdings. Set \"csv\" to print as a CSV or \"json\" for JSON. Defaults to JSON.")
 	printCmd.Flags().StringVar(&configPath, "config", "", "config file (default is $HOME/.ticker.yaml)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,13 @@ var (
 		Args:   cli.Validate(&config, &options, &err),
 		Run:    print.Run(&dep, &ctx, &optionsPrint),
 	}
+	valueCmd = &cobra.Command{
+		Use:    "print-value",
+		Short:  "Prints portfolio value",
+		PreRun: initContext,
+		Args:   cli.Validate(&config, &options, &err),
+		Run:    print.RunValue(&dep, &ctx, &optionsPrint),
+	}
 )
 
 // Execute starts the CLI or prints an error is there is one
@@ -61,6 +68,7 @@ func init() { //nolint: gochecknoinits
 	rootCmd.Flags().StringVar(&options.Proxy, "proxy", "", "proxy URL for requests (default is none)")
 	rootCmd.Flags().StringVar(&options.Sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. Set \"value\" to sort by position value. Keep empty to sort according to change percent")
 	rootCmd.AddCommand(printCmd)
+	rootCmd.AddCommand(valueCmd)
 	printCmd.Flags().StringVar(&optionsPrint.Format, "format", "", "output format for printing holdings. Set \"csv\" to print as a CSV or \"json\" for JSON. Defaults to JSON.")
 	printCmd.Flags().StringVar(&configPath, "config", "", "config file (default is $HOME/.ticker.yaml)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,12 +38,12 @@ var (
 		Args:   cli.Validate(&config, &options, &err),
 		Run:    print.Run(&dep, &ctx, &optionsPrint),
 	}
-	valueCmd = &cobra.Command{
-		Use:    "print-value",
-		Short:  "Prints portfolio value",
+	printSummaryCmd = &cobra.Command{
+		Use:    "print-summary",
+		Short:  "Prints holdings summary",
 		PreRun: initContext,
 		Args:   cli.Validate(&config, &options, &err),
-		Run:    print.RunValue(&dep, &ctx, &optionsPrint),
+		Run:    print.RunSummary(&dep, &ctx, &optionsPrint),
 	}
 )
 
@@ -68,7 +68,7 @@ func init() { //nolint: gochecknoinits
 	rootCmd.Flags().StringVar(&options.Proxy, "proxy", "", "proxy URL for requests (default is none)")
 	rootCmd.Flags().StringVar(&options.Sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. Set \"value\" to sort by position value. Keep empty to sort according to change percent")
 	rootCmd.AddCommand(printCmd)
-	rootCmd.AddCommand(valueCmd)
+	rootCmd.AddCommand(printSummaryCmd)
 	printCmd.Flags().StringVar(&optionsPrint.Format, "format", "", "output format for printing holdings. Set \"csv\" to print as a CSV or \"json\" for JSON. Defaults to JSON.")
 	printCmd.Flags().StringVar(&configPath, "config", "", "config file (default is $HOME/.ticker.yaml)")
 }

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -101,17 +101,15 @@ func Run(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Comm
 	}
 }
 
-// RunValue prints holdings value to the terminal
-func RunValue(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Command, []string) {
+// RunSummary prints holdings summary to the terminal
+func RunSummary(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Command, []string) {
 	return func(_ *cobra.Command, _ []string) {
 		
 		assetGroupQuote := quote.GetAssetGroupQuote(*dep)(ctx.Groups[0])
 		_, holdingSummary := asset.GetAssets(*ctx, assetGroupQuote)
 
-		fmt.Printf("Day change (amount):\t%.2f\n", holdingSummary.DayChange.Amount)
-		fmt.Printf("Day change (percent):\t%.2f\n", holdingSummary.DayChange.Percent)
-		fmt.Printf("Total change (amount):\t%.2f\n", holdingSummary.TotalChange.Amount)
-		fmt.Printf("Total change (percent):\t%.2f\n", holdingSummary.TotalChange.Percent)
+		fmt.Printf("Day change:\t%.2f (%.2f%%)\n", holdingSummary.DayChange.Amount, holdingSummary.DayChange.Percent)
+		fmt.Printf("Total change:\t%.2f (%.2f%%)\n", holdingSummary.TotalChange.Amount, holdingSummary.TotalChange.Percent)
 		fmt.Printf("Value:\t%.2f\n", holdingSummary.Value)
 		fmt.Printf("Cost:\t%.2f\n", holdingSummary.Cost)
 

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -17,6 +17,7 @@ import (
 // Options to configure print behavior
 type Options struct {
 	Format string
+	Summary bool
 }
 
 type jsonRow struct {
@@ -89,10 +90,18 @@ func Run(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Comm
 	return func(_ *cobra.Command, _ []string) {
 
 		assetGroupQuote := quote.GetAssetGroupQuote(*dep)(ctx.Groups[0])
-		assets, _ := asset.GetAssets(*ctx, assetGroupQuote)
+		assets, holdingSummary := asset.GetAssets(*ctx, assetGroupQuote)
 
 		if options.Format == "csv" {
 			fmt.Println(convertAssetsToCSV(assets))
+
+			return
+		}
+		if options.Summary {
+			fmt.Printf("Day change:\t%.2f (%.2f%%)\n", holdingSummary.DayChange.Amount, holdingSummary.DayChange.Percent)
+			fmt.Printf("Total change:\t%.2f (%.2f%%)\n", holdingSummary.TotalChange.Amount, holdingSummary.TotalChange.Percent)
+			fmt.Printf("Value:\t\t%.2f\n", holdingSummary.Value)
+			fmt.Printf("Cost:\t\t%.2f\n", holdingSummary.Cost)
 
 			return
 		}
@@ -101,17 +110,3 @@ func Run(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Comm
 	}
 }
 
-// RunSummary prints holdings summary to the terminal
-func RunSummary(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Command, []string) {
-	return func(_ *cobra.Command, _ []string) {
-		
-		assetGroupQuote := quote.GetAssetGroupQuote(*dep)(ctx.Groups[0])
-		_, holdingSummary := asset.GetAssets(*ctx, assetGroupQuote)
-
-		fmt.Printf("Day change:\t%.2f (%.2f%%)\n", holdingSummary.DayChange.Amount, holdingSummary.DayChange.Percent)
-		fmt.Printf("Total change:\t%.2f (%.2f%%)\n", holdingSummary.TotalChange.Amount, holdingSummary.TotalChange.Percent)
-		fmt.Printf("Value:\t%.2f\n", holdingSummary.Value)
-		fmt.Printf("Cost:\t%.2f\n", holdingSummary.Cost)
-
-	}
-}

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -100,3 +100,20 @@ func Run(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Comm
 		fmt.Println(convertAssetsToJSON(assets))
 	}
 }
+
+// RunValue prints holdings value to the terminal
+func RunValue(dep *c.Dependencies, ctx *c.Context, options *Options) func(*cobra.Command, []string) {
+	return func(_ *cobra.Command, _ []string) {
+		
+		assetGroupQuote := quote.GetAssetGroupQuote(*dep)(ctx.Groups[0])
+		_, holdingSummary := asset.GetAssets(*ctx, assetGroupQuote)
+
+		fmt.Printf("Day change (amount):\t%.2f\n", holdingSummary.DayChange.Amount)
+		fmt.Printf("Day change (percent):\t%.2f\n", holdingSummary.DayChange.Percent)
+		fmt.Printf("Total change (amount):\t%.2f\n", holdingSummary.TotalChange.Amount)
+		fmt.Printf("Total change (percent):\t%.2f\n", holdingSummary.TotalChange.Percent)
+		fmt.Printf("Value:\t%.2f\n", holdingSummary.Value)
+		fmt.Printf("Cost:\t%.2f\n", holdingSummary.Cost)
+
+	}
+}


### PR DESCRIPTION
A small patch that adds feature for printing holding summary (cost, value, day change, total change) in the terminal.
Easily parseable using AWK - see the readme.

Fixes #180 