### PR TITLE
feat: Compose groups via include-groups for reusable tabs and summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,41 @@ Watchlists and holdings can be grouped in `.ticker.yml` under the `groups` prope
 * If top level `watchlist` or `lots` properties are defined in the configuration file, the entries there will be added to a group named `default` which will always be shown first
 * Ordering is defined by order in the configuration file
 * The `holdings` property replaces `lots` under `groups` but serves the same purpose
+* New: `include-groups` allows composing a group from other groups without duplicating entries. The effective watchlist is the concatenation of included groups’ watchlists (then the group’s own), de-duplicated by first occurrence; holdings are concatenated (lots aggregate by symbol automatically in summaries)
+
+Example composite group:
+
+```yaml
+groups:
+  - name: crypto
+    watchlist: [BTC-USD, ETH-USD]
+    holdings:
+      - symbol: BTC-USD
+        quantity: 0.75
+        unit_cost: 35000
+
+  - name: personal stocks
+    watchlist: [AAPL, MSFT]
+    holdings:
+      - symbol: AAPL
+        quantity: 20
+        unit_cost: 130
+
+  - name: personal holding
+    include-groups: [crypto, personal stocks]
+    # Optional extras specific to this composite
+    watchlist: [SOL.X]
+    holdings:
+      - symbol: MSFT
+        quantity: 3
+        unit_cost: 310
+```
+
+Notes:
+- Includes are resolved recursively; cyclic includes are invalid.
+- `default` (created from top-level `watchlist`/`lots`) may be referenced.
+- Forward references are allowed: a composite group can include groups
+  declared later in the file.
 
 ### Data Sources & Symbols
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -44,9 +44,10 @@ type ConfigColorScheme struct {
 }
 
 type ConfigAssetGroup struct {
-	Name      string   `yaml:"name"`
-	Watchlist []string `yaml:"watchlist"`
-	Holdings  []Lot    `yaml:"holdings"`
+	Name          string   `yaml:"name"`
+	Watchlist     []string `yaml:"watchlist"`
+	Holdings      []Lot    `yaml:"holdings"`
+	IncludeGroups []string `yaml:"include-groups"`
 }
 
 type AssetGroup struct {


### PR DESCRIPTION
First off, thank you for creating ticker — I use it daily and it’s been incredibly useful. Also, apologies for the unsolicited PR; I hope this enhancement aligns with the project’s direction.

## Summary

  - Adds include-groups to group configs so one group can reuse other groups’ watchlists and holdings without copy‑pasting.
  - Enables composite tabs and combined summaries (e.g., “personal holding” = “crypto” + “personal stocks”).
  - Supports nesting and forward references (a composite can include groups defined later).
  - Errors on unknown or cyclic includes; preserves declaration order.

## Why

I often want a “summary” group that combines a few existing groups (e.g., crypto + personal stocks) without duplicating config. This adds that capability while remaining backward compatible and predictable.

##  Config Usage

  - New key: include-groups
  - Effective behavior for a composite group:
      - Watchlist = [included groups’ watchlists in include order] + [this group’s watchlist], de‑duplicated by first occurrence.
      - Holdings = [included groups’ holdings in include order] + [this group’s holdings]; aggregation by symbol remains as today for summaries.
      - You can include default (from top-level watchlist/lots).
      - Cyclic/unknown includes are reported as config errors.

##  Implementation

  - Schema: Add `IncludeGroups []string` to `ConfigAssetGroup`.
  - Validation: Check for duplicate group names; detect unknown/cyclic includes.
  - Resolution: Recursively expand include-groups, then:
      - De‑duplicate the resulting watchlist (first‑seen), leave holdings concatenated (existing aggregation applies).
  - Refactor: Extract small unexported helpers for clarity:
      - `resolveGroupIncludes`, `dedupePreserveOrder`, `symbolsBySource`.
  - UI/printing: No changes required — they use the effective group data.
  - Docs: Update README with example, rules, and note on forward references.
  - Tests: Add cases for composition, unknown/cyclic includes, and forward‑declared groups.

 ## Notes

  - Backward compatible: Existing configs work unchanged.
  - Order: Final group order follows the config file; within a composite, included groups’ items come first, then the group’s own.
  - Performance: Simple DFS per composite group; negligible overhead at startup.

  Thank you again for ticker and for considering this improvement. Happy to adjust naming, error messages, or structure to better fit the project’s style.