### PR TITLE
ci: lint pull request titles to enforce conventional squash commits

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,15 +7,25 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   pr-title:
     runs-on: ubuntu-latest
+    # The PR title becomes the squash-merge commit title by default, so lint
+    # it against conventional-commit rules to keep the squashed commit on the
+    # default branch valid. The title is read via env (not interpolated into
+    # the script) to avoid shell injection.
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
-      # The PR title becomes the squash-merge commit title by default, so
-      # lint it against the same conventional-commit rules as commitlint to
-      # keep the squashed commit on the default branch valid.
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate PR title is a conventional commit
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+'
+          if ! printf '%s' "$PR_TITLE" | grep -Eq "$pattern"; then
+            echo "::error::PR title \"$PR_TITLE\" is not a valid conventional commit."
+            echo "Expected: <type>(optional scope): <subject>  e.g. 'feat: add minor currency support'"
+            echo "Valid types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+            exit 1
+          fi
+          echo "PR title OK: $PR_TITLE"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,21 @@
+name: lint-pr-title
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      # The PR title becomes the squash-merge commit title by default, so
+      # lint it against the same conventional-commit rules as commitlint to
+      # keep the squashed commit on the default branch valid.
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

PR #372 squash-merged with the title \`Feat/minor currency support (#372)\`, which is not a valid conventional commit. Because squash-merge defaults the commit title to the PR title, this landed on \`master\` and failed the \`lint-commit-message\` workflow (\`type-empty\`, \`subject-empty\`).

Local \`pre-commit\`/\`pre-push\` hooks can't catch this — the squash commit is created server-side by GitHub, never on a contributor's machine.

## What

Adds a \`lint-pr-title\` workflow using \`amannn/action-semantic-pull-request\` that validates the PR title against conventional-commit rules on open/edit/synchronize. Make it a required status check so a malformed title blocks merge.

## Follow-up (manual, repo settings)

- Settings → General → "Default to PR title for squash merge commits" (so the linted title is what actually lands).
- Branch protection → require the \`lint-pr-title\` check.