### PR TITLE
feat: implement caching for reference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ ticker -w NET,AAPL,TSLA
 |`show-positions`   |  |--show-positions   |                |show positions including weight, average cost, and quantity|
 |`sort`             |  |--sort             |                |sort quotes on the UI - options are change percent (default), `alpha`, `value`, and `user`|
 |`version`          |  |--version          |                |print the current version number|
-|`debug`            |  |                   |                |enable debug logging to `./ticker-log-<date>.log`|
+|`cache`            |  |--no-cache         |`true`          |cache data retrieved at startup|
+|`debug`            |  |--debug            |                |enable debug logging to `./ticker-log-<date>.log`|
 
 ## Configuration
 
@@ -192,6 +193,10 @@ These are the behaviors for a minor unit quote:
 * No `currency` set (or `currency-summary-only: true`) - per-position values, quote price, and the cost basis are all displayed in the minor unit and cost basis should be set in the minor unit
 * `currency` is set - all displayed values are converted to the major unit. Cost basis should still be entered in the minor unit
 * `currency` is set with `currency-disable-unit-cost-conversion` - displayed values are converted to the major unit and cost basis should be set in the major unit
+
+### Cache
+
+`ticker` caches reference data to single local file shared between sessions and instances of `ticker` to speed up startup. The cache can be disabled with `--no-cache` flag or `cache: false` in `.ticker.yaml`.
 
 ### Custom Color Schemes
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,8 @@ func init() { //nolint: gochecknoinits
 	rootCmd.Flags().BoolVar(&options.ShowPositions, "show-positions", false, "display average unit cost, quantity, portfolio weight")
 	rootCmd.Flags().BoolVar(&options.ShowHoldings, "show-holdings", false, "display average unit cost, quantity, portfolio weight (deprecated: use --show-positions)")
 	rootCmd.Flags().StringVar(&options.Sort, "sort", "", "sort quotes on the UI. Set \"alpha\" to sort by ticker name. Set \"value\" to sort by position value. Keep empty to sort according to change percent")
+	rootCmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "disable the on-disk cache of data retrieved at startup")
+	rootCmd.Flags().BoolVar(&options.Debug, "debug", false, "enable debug logging to ./ticker-log-<date>.log")
 
 	printCmd.PersistentFlags().StringVar(&optionsPrint.Format, "format", "", "output format for printing holdings. Set \"csv\" to print as a CSV or \"json\" for JSON. Defaults to JSON.")
 	printCmd.PersistentFlags().StringVar(&configPath, "config", "", "config file (default is $HOME/.ticker.yaml)")

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,172 @@
+// Package cache provides a simple file-based, inter-process cache for data
+// fetched at startup (e.g. the symbol map, Yahoo session, currency lookups) and
+// other slow-changing data such as the latest-version check. Multiple ticker
+// instances running on the same machine share a single JSON file so that only
+// the first instance to fetch a given piece of data (within its TTL) pays the
+// cost of the network request.
+//
+// Each entry carries its own expiry, set by the caller via Set, so that
+// long-lived data (symbol map, session, per-symbol currency) can be reused for
+// much longer than volatile data (currency rates).
+//
+// All keys are namespaced with schemaVersion so that, after a ticker upgrade
+// that changes the shape of any cached value, entries written by the previous
+// version are simply not found (and are pruned on the next write) rather than
+// being decoded into the new shape and silently misread. Bump schemaVersion
+// whenever a cached value's structure changes.
+package cache
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/adrg/xdg"
+	"github.com/spf13/afero"
+)
+
+const schemaVersion = 1
+
+type entry struct {
+	ExpiresAt time.Time       `json:"expires_at"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// keyPrefix is prepended to every key to namespace entries by cache schema
+// version (e.g. "v1:").
+func keyPrefix() string {
+	return "v" + strconv.Itoa(schemaVersion) + ":"
+}
+
+// Cache is a file-backed key/value store with a per-entry TTL. When disabled,
+// all operations are no-ops and Get always reports a miss.
+type Cache struct {
+	fs      afero.Fs
+	path    string
+	enabled bool
+	mu      sync.Mutex
+	entries map[string]entry
+}
+
+// FilePath returns the default location of the shared cache file.
+func FilePath() string {
+	return filepath.Join(xdg.CacheHome, "ticker", "cache.json")
+}
+
+// New creates a cache backed by the file at path. When enabled is false the
+// returned cache neither reads nor writes the file. The existing file (if any)
+// is loaded into memory so reads during this session are served without
+// re-reading the file.
+func New(fs afero.Fs, path string, enabled bool) *Cache {
+	cache := &Cache{
+		fs:      fs,
+		path:    path,
+		enabled: enabled,
+		entries: make(map[string]entry),
+	}
+
+	if enabled {
+		cache.entries = readEntries(fs, path)
+	}
+
+	return cache
+}
+
+// Get reports whether key has a fresh entry and, if so, decodes its payload
+// into out. It returns false on a disabled cache, a missing key, an expired
+// entry, or a decode error.
+func (c *Cache) Get(key string, out any) bool {
+	if !c.enabled {
+		return false
+	}
+
+	c.mu.Lock()
+	cached, exists := c.entries[keyPrefix()+key]
+	c.mu.Unlock()
+
+	if !exists {
+		return false
+	}
+
+	if !time.Now().Before(cached.ExpiresAt) {
+		return false
+	}
+
+	if err := json.Unmarshal(cached.Payload, out); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// Set stores value under key with the given time-to-live and persists the cache
+// file. It is a no-op on a disabled cache. Failures to marshal or persist are
+// silently ignored - the cache is an optimization and must never break startup.
+func (c *Cache) Set(key string, value any, ttl time.Duration) {
+	if !c.enabled {
+		return
+	}
+
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Re-read the file and merge so entries written by other instances since
+	// this cache was created are not clobbered (last-writer-wins per key).
+	c.entries = readEntries(c.fs, c.path)
+
+	// Drop entries written under a different cache schema version so the file
+	// does not accumulate unreadable data across ticker upgrades.
+	prefix := keyPrefix()
+	for existingKey := range c.entries {
+		if !strings.HasPrefix(existingKey, prefix) {
+			delete(c.entries, existingKey)
+		}
+	}
+
+	c.entries[prefix+key] = entry{ExpiresAt: time.Now().Add(ttl), Payload: payload}
+
+	writeEntries(c.fs, c.path, c.entries)
+}
+
+func readEntries(fs afero.Fs, path string) map[string]entry {
+	entries := make(map[string]entry)
+
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return entries
+	}
+
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return make(map[string]entry)
+	}
+
+	return entries
+}
+
+func writeEntries(fs afero.Fs, path string, entries map[string]entry) {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return
+	}
+
+	if err := fs.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return
+	}
+
+	// Write to a temp file and rename so a concurrent reader never observes a
+	// partially written file.
+	tmpPath := path + ".tmp"
+	if err := afero.WriteFile(fs, tmpPath, data, 0600); err != nil {
+		return
+	}
+
+	_ = fs.Rename(tmpPath, path)
+}

--- a/internal/cache/cache_suite_test.go
+++ b/internal/cache/cache_suite_test.go
@@ -1,0 +1,15 @@
+package cache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+)
+
+func TestCache(t *testing.T) {
+	format.TruncatedDiff = false
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cache Suite")
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,155 @@
+package cache_test
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"github.com/achannarasappa/ticker/v5/internal/cache"
+)
+
+const (
+	cachePath = "/cache/ticker/cache.json"
+	testTTL   = time.Hour
+)
+
+type payload struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+var _ = Describe("Cache", func() {
+
+	var fs afero.Fs
+
+	BeforeEach(func() {
+		fs = afero.NewMemMapFs()
+	})
+
+	Describe("FilePath", func() {
+		It("returns a path under the ticker cache directory", func() {
+			Expect(cache.FilePath()).To(HaveSuffix("ticker/cache.json"))
+		})
+	})
+
+	Describe("Get and Set", func() {
+
+		When("the cache is enabled", func() {
+
+			It("round-trips a stored value", func() {
+				cache := cache.New(fs, cachePath, true)
+				cache.Set("key", payload{Name: "abc", Count: 3}, testTTL)
+
+				var out payload
+				hit := cache.Get("key", &out)
+
+				Expect(hit).To(BeTrue())
+				Expect(out).To(Equal(payload{Name: "abc", Count: 3}))
+			})
+
+			It("returns false for a key that was never set", func() {
+				cache := cache.New(fs, cachePath, true)
+
+				var out payload
+				Expect(cache.Get("missing", &out)).To(BeFalse())
+			})
+
+			It("returns false for an entry older than its TTL", func() {
+				cache := cache.New(fs, cachePath, true)
+				cache.Set("key", payload{Name: "stale"}, -time.Minute)
+
+				var out payload
+				Expect(cache.Get("key", &out)).To(BeFalse())
+			})
+		})
+
+		When("the cache is disabled", func() {
+
+			It("does not store values and always misses", func() {
+				cache := cache.New(fs, cachePath, false)
+				cache.Set("key", payload{Name: "abc"}, testTTL)
+
+				var out payload
+				Expect(cache.Get("key", &out)).To(BeFalse())
+			})
+
+			It("does not write a cache file", func() {
+				cache := cache.New(fs, cachePath, false)
+				cache.Set("key", payload{Name: "abc"}, testTTL)
+
+				exists, _ := afero.Exists(fs, cachePath)
+				Expect(exists).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("persistence across instances", func() {
+
+		It("reads values written by a previous instance sharing the same file", func() {
+			writer := cache.New(fs, cachePath, true)
+			writer.Set("key", payload{Name: "persisted", Count: 7}, testTTL)
+
+			reader := cache.New(fs, cachePath, true)
+			var out payload
+			hit := reader.Get("key", &out)
+
+			Expect(hit).To(BeTrue())
+			Expect(out).To(Equal(payload{Name: "persisted", Count: 7}))
+		})
+
+		It("merges entries written by separate instances rather than clobbering", func() {
+			a := cache.New(fs, cachePath, true)
+			a.Set("a", payload{Name: "first"}, testTTL)
+
+			b := cache.New(fs, cachePath, true)
+			b.Set("b", payload{Name: "second"}, testTTL)
+
+			reader := cache.New(fs, cachePath, true)
+			var outA, outB payload
+			Expect(reader.Get("a", &outA)).To(BeTrue())
+			Expect(reader.Get("b", &outB)).To(BeTrue())
+			Expect(outA.Name).To(Equal("first"))
+			Expect(outB.Name).To(Equal("second"))
+		})
+	})
+
+	Describe("cache schema versioning", func() {
+
+		// writeRawEntry writes a cache file containing a single entry under the
+		// given raw (already-namespaced) key, simulating data written by a
+		// ticker version using a different cache schema.
+		writeRawEntry := func(rawKey string, p payload) {
+			type rawEntry struct {
+				ExpiresAt time.Time       `json:"expires_at"`
+				Payload   json.RawMessage `json:"payload"`
+			}
+			encodedPayload, _ := json.Marshal(p)
+			data, _ := json.Marshal(map[string]rawEntry{
+				rawKey: {ExpiresAt: time.Now().Add(time.Hour), Payload: encodedPayload},
+			})
+			afero.WriteFile(fs, cachePath, data, 0600) //nolint:errcheck
+		}
+
+		It("ignores entries written under a different schema version", func() {
+			writeRawEntry("v0:key", payload{Name: "old"})
+
+			var out payload
+			Expect(cache.New(fs, cachePath, true).Get("key", &out)).To(BeFalse())
+		})
+
+		It("prunes entries from other schema versions when writing", func() {
+			writeRawEntry("v0:key", payload{Name: "old"})
+
+			cache.New(fs, cachePath, true).Set("key", payload{Name: "new"}, testTTL)
+
+			var onDisk map[string]json.RawMessage
+			data, _ := afero.ReadFile(fs, cachePath)
+			Expect(json.Unmarshal(data, &onDisk)).To(Succeed())
+			Expect(onDisk).NotTo(HaveKey("v0:key"))
+			Expect(onDisk).To(HaveLen(1))
+		})
+	})
+})

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	"github.com/achannarasappa/ticker/v5/internal/cli/symbol"
 	c "github.com/achannarasappa/ticker/v5/internal/common"
 	"github.com/achannarasappa/ticker/v5/internal/ui/util"
@@ -31,6 +32,8 @@ type Options struct {
 	ShowHoldings          bool // Deprecated: use ShowPositions instead, kept for backwards compatibility
 	ShowPositions         bool // Preferred field name
 	Sort                  string
+	NoCache               bool
+	Debug                 bool
 }
 
 type symbolSource struct {
@@ -137,7 +140,19 @@ func GetContext(d c.Dependencies, config c.Config) (c.Context, error) {
 		err       error
 	)
 
-	groups, err = getGroups(config, d)
+	var logger *log.Logger
+
+	if config.Debug {
+		logger, err = getLogger(d)
+
+		if err != nil {
+			return c.Context{}, err
+		}
+	}
+
+	cache := cache.New(d.Fs, cache.FilePath(), cacheEnabled(config.Cache))
+
+	groups, err = getGroups(config, d, cache)
 
 	if err != nil {
 		return c.Context{}, err
@@ -149,21 +164,12 @@ func GetContext(d c.Dependencies, config c.Config) (c.Context, error) {
 		return c.Context{}, err
 	}
 
-	var logger *log.Logger
-
-	if config.Debug {
-		logger, err = getLogger(d)
-
-		if err != nil {
-			return c.Context{}, err
-		}
-	}
-
 	context := c.Context{
 		Reference: reference,
 		Config:    config,
 		Groups:    groups,
 		Logger:    logger,
+		Cache:     cache,
 	}
 
 	return context, err
@@ -232,8 +238,33 @@ func GetConfig(dep c.Dependencies, configPath string, options Options) (c.Config
 		config.ShowPositions = showHoldingsFromCLI || showHoldingsFromConfig
 	}
 	config.Sort = getStringOption(options.Sort, config.Sort)
+	config.Cache = getCacheOption(options.NoCache, config.Cache)
+	config.Debug = getBoolOption(options.Debug, config.Debug)
 
 	return config, nil
+}
+
+// cacheEnabled reports whether the cache is enabled, defaulting to on when the
+// config value is unset (nil).
+func cacheEnabled(configValue *bool) bool {
+	return configValue == nil || *configValue
+}
+
+// getCacheOption resolves whether the cache is enabled. The cache defaults to on
+// and is disabled only by an explicit `cache: false` in config or the
+// --no-cache flag, with the flag taking precedence.
+func getCacheOption(noCacheFlag bool, configValue *bool) *bool {
+	enabled := true
+
+	if configValue != nil {
+		enabled = *configValue
+	}
+
+	if noCacheFlag {
+		enabled = false
+	}
+
+	return &enabled
 }
 
 func getConfigPath(fs afero.Fs, configPathOption string) (string, error) {
@@ -300,12 +331,12 @@ func getStringOption(cliValue string, configValue string) string {
 	return ""
 }
 
-func getGroups(config c.Config, d c.Dependencies) ([]c.AssetGroup, error) {
+func getGroups(config c.Config, d c.Dependencies, cache c.Cache) ([]c.AssetGroup, error) {
 
 	groups := make([]c.AssetGroup, 0)
 	var configAssetGroups []c.ConfigAssetGroup
 
-	tickerSymbolToSourceSymbol, err := symbol.GetTickerSymbols(d.SymbolsURL)
+	tickerSymbolToSourceSymbol, err := symbol.GetTickerSymbols(d.SymbolsURL, cache)
 
 	if err != nil {
 		return []c.AssetGroup{}, err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -494,14 +494,15 @@ var _ = Describe("Cli", func() {
 
 			When("the config path option is empty", func() {
 				When("there is no config file on disk", func() {
-					It("should return an empty config and no error", func() {
+					It("should return a default config with the cache enabled and no error", func() {
 						inputHome, _ := homedir.Dir()
 						inputConfigPath := ""
+						cacheEnabled := true
 						depLocal.Fs.MkdirAll(inputHome, 0755)
 						outputConfig, outputErr := GetConfig(depLocal, inputConfigPath, cli.Options{})
 
 						Expect(outputErr).NotTo(HaveOccurred())
-						Expect(outputConfig).To(Equal(c.Config{RefreshInterval: 5}))
+						Expect(outputConfig).To(Equal(c.Config{RefreshInterval: 5, Cache: &cacheEnabled}))
 					})
 				})
 				When("there is a config file in the home directory", func() {

--- a/internal/cli/symbol/symbol.go
+++ b/internal/cli/symbol/symbol.go
@@ -6,9 +6,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	c "github.com/achannarasappa/ticker/v5/internal/common"
 )
+
+// ttlSymbolMap is how long the symbol source map is cached. It is sourced from a
+// static CSV that changes rarely, so it can be reused for a long time.
+const ttlSymbolMap = 7 * 24 * time.Hour
 
 type SymbolSourceMap struct { //nolint:golint,revive
 	TickerSymbol string
@@ -59,8 +64,19 @@ func parseTickerSymbolToSourceSymbol(body io.ReadCloser) (TickerSymbolToSourceSy
 	return out, nil
 }
 
-// GetTickerSymbols retrieves a list of ticker specific symbols and their data source
-func GetTickerSymbols(url string) (TickerSymbolToSourceSymbol, error) {
+// GetTickerSymbols retrieves a list of ticker specific symbols and their data
+// source. When a cache is provided and holds a fresh entry, the symbols are
+// served from it without a network request.
+func GetTickerSymbols(url string, cache c.Cache) (TickerSymbolToSourceSymbol, error) {
+	cacheKey := "symbols:" + url
+
+	if cache != nil {
+		var cached TickerSymbolToSourceSymbol
+		if cache.Get(cacheKey, &cached) {
+			return cached, nil
+		}
+	}
+
 	resp, err := http.Get(url) //nolint:gosec
 	if err != nil {
 		return TickerSymbolToSourceSymbol{}, err
@@ -74,6 +90,10 @@ func GetTickerSymbols(url string) (TickerSymbolToSourceSymbol, error) {
 	tickerSymbolToSourceSymbol, err := parseTickerSymbolToSourceSymbol(resp.Body)
 	if err != nil {
 		return TickerSymbolToSourceSymbol{}, err
+	}
+
+	if cache != nil {
+		cache.Set(cacheKey, tickerSymbolToSourceSymbol, ttlSymbolMap)
 	}
 
 	return tickerSymbolToSourceSymbol, nil

--- a/internal/cli/symbol/symbol_test.go
+++ b/internal/cli/symbol/symbol_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/achannarasappa/ticker/v5/internal/cli/symbol"
 	c "github.com/achannarasappa/ticker/v5/internal/common"
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/spf13/afero"
 )
 
 var _ = Describe("Symbol", func() {
@@ -69,7 +71,7 @@ var _ = Describe("Symbol", func() {
 				},
 			}
 
-			outputSymbols, outputErr := symbol.GetTickerSymbols(server.URL() + "/symbols.csv")
+			outputSymbols, outputErr := symbol.GetTickerSymbols(server.URL()+"/symbols.csv", nil)
 
 			Expect(outputSymbols).To(Equal(expectedSymbols))
 			Expect(outputErr).NotTo(HaveOccurred())
@@ -95,7 +97,7 @@ var _ = Describe("Symbol", func() {
 					},
 				}
 
-				outputSymbols, outputErr := symbol.GetTickerSymbols(server.URL() + "/symbols.csv")
+				outputSymbols, outputErr := symbol.GetTickerSymbols(server.URL()+"/symbols.csv", nil)
 
 				Expect(outputSymbols).To(Equal(expectedSymbols))
 				Expect(outputErr).NotTo(HaveOccurred())
@@ -117,9 +119,33 @@ var _ = Describe("Symbol", func() {
 					),
 				)
 
-				_, outputErr := symbol.GetTickerSymbols(server.URL() + "/symbols.csv")
+				_, outputErr := symbol.GetTickerSymbols(server.URL()+"/symbols.csv", nil)
 
 				Expect(outputErr).To(HaveOccurred())
+			})
+
+		})
+
+		When("a cache is provided", func() {
+
+			It("serves from the cache on a subsequent call without a network request", func() {
+				responseFixture := `"BTC.X","BTC-USDC","cb"
+`
+				server.RouteToHandler("GET", "/symbols.csv",
+					ghttp.CombineHandlers(
+						ghttp.RespondWith(http.StatusOK, responseFixture, http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}}),
+					),
+				)
+
+				cache := cache.New(afero.NewMemMapFs(), "/cache/startup-cache.json", true)
+
+				outputFirst, errFirst := symbol.GetTickerSymbols(server.URL()+"/symbols.csv", cache)
+				outputSecond, errSecond := symbol.GetTickerSymbols(server.URL()+"/symbols.csv", cache)
+
+				Expect(errFirst).NotTo(HaveOccurred())
+				Expect(errSecond).NotTo(HaveOccurred())
+				Expect(outputSecond).To(Equal(outputFirst))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 
 		})
@@ -134,7 +160,7 @@ var _ = Describe("Symbol", func() {
 					),
 				)
 
-				_, outputErr := symbol.GetTickerSymbols(server.URL() + "/symbols.csv")
+				_, outputErr := symbol.GetTickerSymbols(server.URL()+"/symbols.csv", nil)
 
 				Expect(outputErr).To(HaveOccurred())
 			})

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"log"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -12,6 +13,21 @@ type Context struct {
 	Groups    []AssetGroup
 	Reference Reference
 	Logger    *log.Logger
+	Cache     Cache
+}
+
+// Cache is a key/value store for data fetched at startup and other
+// slow-changing data, shared across ticker instances on the same machine.
+// Implementations must tolerate being nil-checked by callers and must never
+// panic on a miss.
+type Cache interface {
+	// Get reports whether key has a fresh entry and, if so, decodes its value
+	// into out. It returns false on a miss, an expired entry, or a decode error.
+	Get(key string, out any) bool
+	// Set stores value under key with the given time-to-live. Failures are
+	// silently ignored since the cache is an optimization that must never break
+	// startup.
+	Set(key string, value any, ttl time.Duration)
 }
 
 // Config represents user defined configuration
@@ -32,6 +48,11 @@ type Config struct {
 	ColorScheme                       ConfigColorScheme  `yaml:"colors"`
 	AssetGroup                        []ConfigAssetGroup `yaml:"groups"`
 	Debug                             bool               `yaml:"debug"`
+	// Cache enables the on-disk cache. It is a pointer so that an unset config
+	// value (nil) can be distinguished from an explicit false, allowing the
+	// cache to default to on while still being disableable via config or
+	// --no-cache.
+	Cache *bool `yaml:"cache"`
 }
 
 // ConfigColorScheme represents user defined color scheme

--- a/internal/monitor/coinbase/monitor-price/monitor.go
+++ b/internal/monitor/coinbase/monitor-price/monitor.go
@@ -15,7 +15,11 @@ import (
 )
 
 const (
-	fromCurrencyCode = "USD"
+	fromCurrencyCode   = "USD"
+	cacheKeyUnderlying = "coinbase:underlying:"
+	// ttlUnderlying caches the mapping from a futures product to its underlying
+	// asset, which does not change for the life of the contract.
+	ttlUnderlying = 7 * 24 * time.Hour
 )
 
 type MonitorPriceCoinbase struct {
@@ -43,6 +47,7 @@ type MonitorPriceCoinbase struct {
 	isStarted                        bool
 	chanUpdateAssetQuote             chan c.MessageUpdate[c.AssetQuote]
 	chanRequestCurrencyRates         chan []string // Channel for currency rate requests
+	cache                            c.Cache
 }
 
 type input struct {
@@ -57,6 +62,7 @@ type Config struct {
 	ChanError                chan error
 	ChanUpdateAssetQuote     chan c.MessageUpdate[c.AssetQuote]
 	ChanRequestCurrencyRates chan []string
+	Cache                    c.Cache
 }
 
 // Option defines an option for configuring the monitor
@@ -81,6 +87,7 @@ func NewMonitorPriceCoinbase(config Config, opts ...Option) *MonitorPriceCoinbas
 		cancel:                           cancel,
 		chanUpdateAssetQuote:             config.ChanUpdateAssetQuote,
 		chanRequestCurrencyRates:         config.ChanRequestCurrencyRates,
+		cache:                            config.Cache,
 	}
 
 	pollerConfig := poller.PollerConfig{
@@ -493,21 +500,48 @@ func (m *MonitorPriceCoinbase) getUnderlyingAssetsAndUpdateProductIds() error {
 		return nil
 	}
 
-	// Get new quotes for symbols with underlying assets in order to get their underlying symbols
-	underlyingAssetQuotes, _, err := m.unaryAPI.GetAssetQuotes(symbolsWithUnderlying)
-	if err != nil {
-		return err
+	// The mapping between a futures product and its underlying asset is reference
+	// data that does not change, so resolve it from the cache where possible and
+	// only fetch the symbols that are missing from the cache.
+	resolvedUnderlyings := make(map[string]string)
+	symbolsToFetch := make([]string, 0, len(symbolsWithUnderlying))
+
+	for _, productId := range symbolsWithUnderlying {
+		var underlying string
+		if m.cache != nil && m.cache.Get(cacheKeyUnderlying+productId, &underlying) {
+			resolvedUnderlyings[productId] = underlying
+
+			continue
+		}
+
+		symbolsToFetch = append(symbolsToFetch, productId)
+	}
+
+	if len(symbolsToFetch) > 0 {
+		// Get new quotes for symbols with underlying assets in order to get their underlying symbols
+		underlyingAssetQuotes, _, err := m.unaryAPI.GetAssetQuotes(symbolsToFetch)
+		if err != nil {
+			return err
+		}
+
+		for _, quote := range underlyingAssetQuotes {
+			resolvedUnderlyings[quote.Meta.SymbolInSourceAPI] = quote.QuoteFutures.SymbolUnderlying
+
+			if m.cache != nil {
+				m.cache.Set(cacheKeyUnderlying+quote.Meta.SymbolInSourceAPI, quote.QuoteFutures.SymbolUnderlying, ttlUnderlying)
+			}
+		}
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for _, quote := range underlyingAssetQuotes {
+	for productId, underlying := range resolvedUnderlyings {
 		// Add mapping between symbol and underlying symbol to map for lookup
-		m.productIdsToUnderlyingProductIds[quote.Meta.SymbolInSourceAPI] = quote.QuoteFutures.SymbolUnderlying
+		m.productIdsToUnderlyingProductIds[productId] = underlying
 
 		// Append underlying symbol to list of all symbols
-		underlyingSymbolsResponse = append(underlyingSymbolsResponse, quote.QuoteFutures.SymbolUnderlying)
+		underlyingSymbolsResponse = append(underlyingSymbolsResponse, underlying)
 	}
 
 	// Merge and deduplicate productIds since and underlying symbol could also have been explicitly requested

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -37,6 +37,7 @@ type ConfigMonitor struct {
 	RefreshInterval int
 	TargetCurrency  string
 	Logger          *log.Logger
+	Cache           c.Cache
 	ConfigMonitorPriceCoinbase
 	ConfigMonitorsYahoo
 }
@@ -78,6 +79,7 @@ func NewMonitor(configMonitor ConfigMonitor) (*Monitor, error) {
 			ChanError:                chanError,
 			ChanUpdateAssetQuote:     chanUpdateAssetQuote,
 			ChanRequestCurrencyRates: chanRequestCurrencyRate,
+			Cache:                    configMonitor.Cache,
 		},
 		monitorPriceCoinbase.WithStreamingURL(configMonitor.ConfigMonitorPriceCoinbase.StreamingURL),
 		monitorPriceCoinbase.WithRefreshInterval(time.Duration(configMonitor.RefreshInterval)*time.Second),
@@ -89,6 +91,7 @@ func NewMonitor(configMonitor ConfigMonitor) (*Monitor, error) {
 		SessionRootURL:    configMonitor.ConfigMonitorsYahoo.SessionRootURL,
 		SessionCrumbURL:   configMonitor.ConfigMonitorsYahoo.SessionCrumbURL,
 		SessionConsentURL: configMonitor.ConfigMonitorsYahoo.SessionConsentURL,
+		Cache:             configMonitor.Cache,
 	})
 
 	yahoo := monitorPriceYahoo.NewMonitorPriceYahoo(
@@ -98,6 +101,7 @@ func NewMonitor(configMonitor ConfigMonitor) (*Monitor, error) {
 			ChanError:                chanError,
 			ChanUpdateAssetQuote:     chanUpdateAssetQuote,
 			ChanRequestCurrencyRates: chanRequestCurrencyRate,
+			Cache:                    configMonitor.Cache,
 		},
 		monitorPriceYahoo.WithRefreshInterval(time.Duration(configMonitor.RefreshInterval)*time.Second),
 	)
@@ -109,6 +113,7 @@ func NewMonitor(configMonitor ConfigMonitor) (*Monitor, error) {
 			ChanUpdateCurrencyRates:  chanUpdateCurrencyRate,
 			ChanRequestCurrencyRates: chanRequestCurrencyRate,
 			ChanError:                chanError,
+			Cache:                    configMonitor.Cache,
 		},
 	)
 

--- a/internal/monitor/yahoo/monitor-currency-rates/monitor.go
+++ b/internal/monitor/yahoo/monitor-currency-rates/monitor.go
@@ -5,14 +5,30 @@ import (
 	"errors"
 	"maps"
 	"sync"
+	"time"
 
 	c "github.com/achannarasappa/ticker/v5/internal/common"
 	"github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/unary"
 )
 
+const (
+	// cacheKeyCurrencyRate namespaces a single from -> to currency rate so
+	// overlapping currencies are shared across instances regardless of the full
+	// set requested.
+	cacheKeyCurrencyRate = "yahoo:currency-rate:"
+	// ttlCurrencyRates is kept short since exchange rates drift continuously.
+	ttlCurrencyRates = time.Hour
+)
+
+// currencyRateKey builds the cache key for a single from -> to currency rate.
+func currencyRateKey(fromCurrency, toCurrency string) string {
+	return cacheKeyCurrencyRate + toCurrency + ":" + fromCurrency
+}
+
 // MonitorCurrencyRatesYahoo represents a Yahoo Finance monitor
 type MonitorCurrencyRateYahoo struct {
 	unaryAPI                 *unary.UnaryAPI
+	cache                    c.Cache
 	ctx                      context.Context
 	cancel                   context.CancelFunc
 	currencyRateCache        map[string]c.CurrencyRate
@@ -31,6 +47,7 @@ type Config struct {
 	ChanUpdateCurrencyRates  chan c.CurrencyRates
 	ChanRequestCurrencyRates chan []string
 	ChanError                chan error
+	Cache                    c.Cache
 }
 
 // NewMonitorCurrencyRateYahoo creates a new MonitorCurrencyRateYahoo
@@ -40,6 +57,7 @@ func NewMonitorCurrencyRateYahoo(config Config) *MonitorCurrencyRateYahoo {
 
 	monitor := &MonitorCurrencyRateYahoo{
 		unaryAPI:                 config.UnaryAPI,
+		cache:                    config.Cache,
 		ctx:                      ctx,
 		cancel:                   cancel,
 		chanUpdateCurrencyRates:  config.ChanUpdateCurrencyRates,
@@ -134,17 +152,42 @@ func (m *MonitorCurrencyRateYahoo) handleRequestCurrencyRates() {
 				continue
 			}
 
-			// Get currency rates from Yahoo unary API
-			rates, err := m.unaryAPI.GetCurrencyRates(fromCurrenciesToRequest, m.targetCurrency)
-			if err != nil {
-				m.chanError <- err
+			// Resolve rates from the on-disk cache
+			resolvedRates := make(map[string]c.CurrencyRate)
+			currenciesToFetch := make([]string, 0, len(fromCurrenciesToRequest))
 
-				continue
+			for _, currency := range fromCurrenciesToRequest {
+				var cached c.CurrencyRate
+				if m.cache != nil && m.cache.Get(currencyRateKey(currency, m.targetCurrency), &cached) {
+					resolvedRates[currency] = cached
+
+					continue
+				}
+
+				currenciesToFetch = append(currenciesToFetch, currency)
+			}
+
+			if len(currenciesToFetch) > 0 {
+				// Get currency rates from Yahoo unary API
+				rates, err := m.unaryAPI.GetCurrencyRates(currenciesToFetch, m.targetCurrency)
+				if err != nil {
+					m.chanError <- err
+
+					continue
+				}
+
+				for currency, rate := range rates {
+					resolvedRates[currency] = rate
+
+					if m.cache != nil {
+						m.cache.Set(currencyRateKey(currency, m.targetCurrency), rate, ttlCurrencyRates)
+					}
+				}
 			}
 
 			// Update the cache
 			m.mu.Lock()
-			maps.Copy(m.currencyRateCache, rates)
+			maps.Copy(m.currencyRateCache, resolvedRates)
 			m.mu.Unlock()
 			m.chanUpdateCurrencyRates <- m.currencyRateCache
 		}

--- a/internal/monitor/yahoo/monitor-currency-rates/monitor_currency_rates_test.go
+++ b/internal/monitor/yahoo/monitor-currency-rates/monitor_currency_rates_test.go
@@ -8,7 +8,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/spf13/afero"
 
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	c "github.com/achannarasappa/ticker/v5/internal/common"
 	. "github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/monitor-currency-rates"
 	"github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/unary"
@@ -216,6 +218,38 @@ var _ = Describe("MonitorCurrencyRates", func() {
 
 						// Only one HTTP request should have been made
 						Expect(server.ReceivedRequests()).To(HaveLen(1))
+					})
+				})
+
+				When("a currency rate is cached on disk", func() {
+					It("should serve it without making a network request", func() {
+						sharedCache := cache.New(afero.NewMemMapFs(), "/cache/ticker/cache.json", true)
+						sharedCache.Set("yahoo:currency-rate:USD:EUR", c.CurrencyRate{FromCurrency: "EUR", ToCurrency: "USD", Rate: 1.1}, time.Hour)
+
+						updateCh := make(chan c.CurrencyRates, 2)
+						requestCh := make(chan []string, 2)
+						errCh := make(chan error, 1)
+
+						monitor := NewMonitorCurrencyRateYahoo(Config{
+							Ctx:                      context.Background(),
+							UnaryAPI:                 client,
+							ChanUpdateCurrencyRates:  updateCh,
+							ChanRequestCurrencyRates: requestCh,
+							ChanError:                errCh,
+							Cache:                    sharedCache,
+						})
+
+						err := monitor.Start()
+						Expect(err).NotTo(HaveOccurred())
+
+						requestCh <- []string{"EUR"}
+
+						var rates c.CurrencyRates
+						Eventually(updateCh, 500*time.Millisecond).Should(Receive(&rates))
+						Expect(rates).To(HaveKeyWithValue("EUR", c.CurrencyRate{FromCurrency: "EUR", ToCurrency: "USD", Rate: 1.1}))
+
+						// The rate was served from the cache so no network request was made
+						Expect(server.ReceivedRequests()).To(BeEmpty())
 					})
 				})
 

--- a/internal/monitor/yahoo/monitor-price/monitor.go
+++ b/internal/monitor/yahoo/monitor-price/monitor.go
@@ -13,10 +13,19 @@ import (
 	unary "github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/unary"
 )
 
+const (
+	// cacheKeyCurrencyMap namespaces cached per-symbol denomination currencies.
+	cacheKeyCurrencyMap = "yahoo:currency-map:"
+	// ttlCurrencyMap caches a symbol's denomination currency, which is effectively
+	// static, so it can be reused for a long time.
+	ttlCurrencyMap = 7 * 24 * time.Hour
+)
+
 // MonitorPriceYahoo represents a Yahoo Finance monitor
 type MonitorPriceYahoo struct {
 	unaryAPI                 *unary.UnaryAPI
 	poller                   *poller.Poller
+	cache                    c.Cache
 	input                    input
 	symbols                  []string
 	symbolToCurrency         map[string]string         // Map of symbols to currency
@@ -47,6 +56,7 @@ type Config struct {
 	ChanError                chan error
 	ChanUpdateAssetQuote     chan c.MessageUpdate[c.AssetQuote]
 	ChanRequestCurrencyRates chan []string
+	Cache                    c.Cache
 }
 
 // Option defines an option for configuring the monitor
@@ -62,6 +72,7 @@ func NewMonitorPriceYahoo(config Config, opts ...Option) *MonitorPriceYahoo {
 		chanPollUpdateAssetQuote: make(chan c.MessageUpdate[c.AssetQuote]),
 		chanError:                config.ChanError,
 		unaryAPI:                 config.UnaryAPI,
+		cache:                    config.Cache,
 		ctx:                      ctx,
 		cancel:                   cancel,
 		chanUpdateAssetQuote:     config.ChanUpdateAssetQuote,
@@ -335,10 +346,36 @@ func (m *MonitorPriceYahoo) getCurrencyForEachSymbolAndUpdateCurrencyMap() error
 	}
 	m.muCurrencyRates.RUnlock()
 
-	// Get the currency each symbol's price quote will be denominated in
-	symbolToCurrency, err := m.unaryAPI.GetCurrencyMap(symbolsWithoutCurrency)
-	if err != nil {
-		return fmt.Errorf("failed to get currency information: %w", err)
+	// Resolve a symbol's currency from cache since the currency
+	// for a symbol is effectively static
+	symbolToCurrency := make(map[string]unary.SymbolToCurrency)
+	symbolsToFetch := make([]string, 0, len(symbolsWithoutCurrency))
+
+	for _, symbol := range symbolsWithoutCurrency {
+		var cached unary.SymbolToCurrency
+		if m.cache != nil && m.cache.Get(cacheKeyCurrencyMap+symbol, &cached) {
+			symbolToCurrency[symbol] = cached
+
+			continue
+		}
+
+		symbolsToFetch = append(symbolsToFetch, symbol)
+	}
+
+	if len(symbolsToFetch) > 0 {
+		// Get the currency each symbol's price quote will be denominated in
+		fetched, err := m.unaryAPI.GetCurrencyMap(symbolsToFetch)
+		if err != nil {
+			return fmt.Errorf("failed to get currency information: %w", err)
+		}
+
+		for symbol, currency := range fetched {
+			symbolToCurrency[symbol] = currency
+
+			if m.cache != nil {
+				m.cache.Set(cacheKeyCurrencyMap+symbol, currency, ttlCurrencyMap)
+			}
+		}
 	}
 
 	m.muCurrencyRates.Lock()

--- a/internal/monitor/yahoo/monitor-price/monitor_test.go
+++ b/internal/monitor/yahoo/monitor-price/monitor_test.go
@@ -9,11 +9,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	c "github.com/achannarasappa/ticker/v5/internal/common"
 	monitorPriceYahoo "github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/monitor-price"
 	"github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/unary"
 
 	"github.com/onsi/gomega/ghttp"
+	"github.com/spf13/afero"
 )
 
 var _ = Describe("Monitor Yahoo", func() {
@@ -673,6 +675,44 @@ var _ = Describe("Monitor Yahoo", func() {
 			})
 		})
 
+	})
+
+	Describe("currency map cache", func() {
+		It("serves a symbol's currency from the cache without a currency network request", func() {
+			sharedCache := cache.New(afero.NewMemMapFs(), "/cache/ticker/cache.json", true)
+			sharedCache.Set("yahoo:currency-map:NET", unary.SymbolToCurrency{Symbol: "NET", FromCurrency: "USD"}, time.Hour)
+			sharedCache.Set("yahoo:currency-map:GOOG", unary.SymbolToCurrency{Symbol: "GOOG", FromCurrency: "USD"}, time.Hour)
+
+			currencyRequested := false
+			server.RouteToHandler(http.MethodGet, "/v7/finance/quote",
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Query().Get("fields") == "regularMarketPrice,currency" {
+						currencyRequested = true
+						json.NewEncoder(w).Encode(currencyResponseFixture) //nolint:errcheck,errchkjson
+
+						return
+					}
+					json.NewEncoder(w).Encode(responseQuote1Fixture) //nolint:errcheck,errchkjson
+				},
+			)
+
+			monitor := monitorPriceYahoo.NewMonitorPriceYahoo(monitorPriceYahoo.Config{
+				UnaryAPI:                 unaryAPI,
+				Ctx:                      context.Background(),
+				ChanRequestCurrencyRates: make(chan []string, 1),
+				Cache:                    sharedCache,
+			}, monitorPriceYahoo.WithRefreshInterval(time.Millisecond*100))
+
+			err := monitor.SetSymbols([]string{"NET", "GOOG"}, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Currencies came from the cache, so no currency lookup was requested
+			Expect(currencyRequested).To(BeFalse())
+
+			assetQuotes, err := monitor.GetAssetQuotes()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(assetQuotes).To(HaveLen(2))
+		})
 	})
 
 })

--- a/internal/monitor/yahoo/unary/unary.go
+++ b/internal/monitor/yahoo/unary/unary.go
@@ -7,8 +7,20 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	c "github.com/achannarasappa/ticker/v5/internal/common"
+)
+
+const (
+	// cacheKeySession identifies the cached Yahoo session (cookies + crumb). The
+	// session is transport-level authentication shared by every Yahoo request, so
+	// it is cached here; use-case data (currency map, currency rates) is cached by
+	// the monitors that own it, not in this transport client.
+	cacheKeySession = "yahoo:session"
+	// ttlSession bounds reuse of the Yahoo session. The session itself is valid
+	// for much longer and is re-established automatically if rejected.
+	ttlSession = 24 * time.Hour
 )
 
 // UnaryAPI is a client for the API
@@ -20,6 +32,7 @@ type UnaryAPI struct {
 	sessionConsentURL string
 	cookies           []*http.Cookie
 	crumb             string
+	cache             c.Cache
 }
 
 // Config contains configuration options for the UnaryAPI client
@@ -28,11 +41,24 @@ type Config struct {
 	SessionRootURL    string
 	SessionCrumbURL   string
 	SessionConsentURL string
+	Cache             c.Cache
 }
 
 type SymbolToCurrency struct {
 	Symbol       string
 	FromCurrency string
+}
+
+// sessionCache is the serializable form of the Yahoo session (cookies + crumb)
+// persisted to the startup cache so it can be shared between ticker instances.
+type sessionCache struct {
+	Cookies []sessionCookie `json:"cookies"`
+	Crumb   string          `json:"crumb"`
+}
+
+type sessionCookie struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // NewUnaryAPI creates a new client
@@ -54,7 +80,46 @@ func NewUnaryAPI(config Config) *UnaryAPI {
 		sessionRootURL:    config.SessionRootURL,
 		sessionCrumbURL:   config.SessionCrumbURL,
 		sessionConsentURL: config.SessionConsentURL,
+		cache:             config.Cache,
 	}
+}
+
+// loadSessionFromCache populates cookies and crumb from the shared cache when
+// available. It returns true on a cache hit.
+func (u *UnaryAPI) loadSessionFromCache() bool {
+	if u.cache == nil {
+		return false
+	}
+
+	var session sessionCache
+	if !u.cache.Get(cacheKeySession, &session) {
+		return false
+	}
+
+	cookies := make([]*http.Cookie, 0, len(session.Cookies))
+	for _, cookie := range session.Cookies {
+		// Reconstructed outbound request cookies; only Name and Value are sent via req.AddCookie
+		cookies = append(cookies, &http.Cookie{Name: cookie.Name, Value: cookie.Value}) //nolint:gosec
+	}
+
+	u.cookies = cookies
+	u.crumb = session.Crumb
+
+	return true
+}
+
+// saveSessionToCache persists the current cookies and crumb to the shared cache.
+func (u *UnaryAPI) saveSessionToCache() {
+	if u.cache == nil {
+		return
+	}
+
+	session := sessionCache{Crumb: u.crumb}
+	for _, cookie := range u.cookies {
+		session.Cookies = append(session.Cookies, sessionCookie{Name: cookie.Name, Value: cookie.Value})
+	}
+
+	u.cache.Set(cacheKeySession, session, ttlSession)
 }
 
 // GetAssetQuotes issues a HTTP request to retrieve quotes from the API and process the response
@@ -168,6 +233,12 @@ func (u *UnaryAPI) GetCurrencyRates(fromCurrencies []string, toCurrency string) 
 
 func (u *UnaryAPI) getQuotes(symbols []string, fields []string) (Response, error) {
 
+	// Reuse a session shared by other instances when one is cached, so the first
+	// request is authenticated and the session handshake can be skipped.
+	if u.crumb == "" && len(u.cookies) == 0 {
+		u.loadSessionFromCache()
+	}
+
 	// Build URL with query parameters
 	reqURL, err := url.Parse(u.baseURL + "/v7/finance/quote")
 	if err != nil {
@@ -221,6 +292,9 @@ func (u *UnaryAPI) getQuotes(symbols []string, fields []string) (Response, error
 		if err := u.refreshSession(); err != nil {
 			return Response{}, fmt.Errorf("session refresh failed: %w", err)
 		}
+
+		// Persist the freshly established session so other instances can reuse it
+		u.saveSessionToCache()
 
 		// Retry request with refreshed session
 		return u.getQuotes(symbols, fields)

--- a/internal/monitor/yahoo/unary/unary_test.go
+++ b/internal/monitor/yahoo/unary/unary_test.go
@@ -1,6 +1,7 @@
 package unary_test
 
 import (
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	c "github.com/achannarasappa/ticker/v5/internal/common"
 	"github.com/achannarasappa/ticker/v5/internal/monitor/yahoo/unary"
 	. "github.com/onsi/ginkgo/v2"
@@ -12,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/gomega/ghttp"
+	"github.com/spf13/afero"
 )
 
 const (
@@ -822,6 +824,42 @@ var _ = Describe("Unary", func() {
 
 	})
 
+	Describe("startup cache", func() {
+
+		var testCache c.Cache
+
+		BeforeEach(func() {
+			testCache = cache.New(afero.NewMemMapFs(), "/cache/startup-cache.json", true)
+		})
+
+		When("a session has been cached by a previous instance", func() {
+			It("reuses it without performing a session handshake", func() {
+				// First instance performs the full session handshake and caches the session
+				firstServer := ghttp.NewServer()
+				defer firstServer.Close()
+				firstClient := newTestClientWithCache(firstServer, testCache)
+				appendQuote401(firstServer, "NET")
+				appendRootSessionOK(firstServer)
+				appendCrumb(firstServer, "gf34y383")
+				appendQuoteWithCrumb(firstServer, "NET", "gf34y383", responseQuote1Fixture)
+
+				_, _, errFirst := firstClient.GetAssetQuotes([]string{"NET"})
+				Expect(errFirst).NotTo(HaveOccurred())
+
+				// Second instance shares the cache and should skip the handshake entirely
+				secondServer := ghttp.NewServer()
+				defer secondServer.Close()
+				secondClient := newTestClientWithCache(secondServer, testCache)
+				appendQuoteWithCrumb(secondServer, "NET", "gf34y383", responseQuote1Fixture)
+
+				_, _, errSecond := secondClient.GetAssetQuotes([]string{"NET"})
+				Expect(errSecond).NotTo(HaveOccurred())
+				Expect(secondServer.ReceivedRequests()).To(HaveLen(1))
+			})
+		})
+
+	})
+
 })
 
 // Create a new API client for testing
@@ -831,6 +869,17 @@ func newTestClient(server *ghttp.Server) *unary.UnaryAPI {
 		SessionRootURL:    server.URL(),
 		SessionCrumbURL:   server.URL(),
 		SessionConsentURL: server.URL(),
+	})
+}
+
+// Create a new API client with a startup cache for testing
+func newTestClientWithCache(server *ghttp.Server, cache c.Cache) *unary.UnaryAPI {
+	return unary.NewUnaryAPI(unary.Config{
+		BaseURL:           server.URL(),
+		SessionRootURL:    server.URL(),
+		SessionCrumbURL:   server.URL(),
+		SessionConsentURL: server.URL(),
+		Cache:             cache,
 	})
 }
 

--- a/internal/ui/start.go
+++ b/internal/ui/start.go
@@ -14,6 +14,7 @@ func Start(dep *c.Dependencies, ctx *c.Context, version string) func() error {
 			RefreshInterval: ctx.Config.RefreshInterval,
 			TargetCurrency:  ctx.Config.Currency,
 			Logger:          ctx.Logger,
+			Cache:           ctx.Cache,
 			ConfigMonitorsYahoo: mon.ConfigMonitorsYahoo{
 				BaseURL:           dep.MonitorYahooBaseURL,
 				SessionRootURL:    dep.MonitorYahooSessionRootURL,

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -3,23 +3,20 @@ package updater
 import (
 	"encoding/json"
 	"net/http"
-	"path/filepath"
 	"time"
 
-	"github.com/adrg/xdg"
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	"github.com/spf13/afero"
 )
 
-const checkInterval = 3 * time.Hour
+const (
+	checkInterval         = 3 * time.Hour
+	cacheKeyLatestVersion = "latest-version"
+)
 
-type cacheEntry struct {
-	CheckedAt     time.Time `json:"checked_at"`
-	LatestVersion string    `json:"latest_version"`
-}
-
-// CacheFilePath returns the path to the update check cache file
+// CacheFilePath returns the path to the cache file
 func CacheFilePath() string {
-	return filepath.Join(xdg.CacheHome, "ticker", "update-check.json")
+	return cache.FilePath()
 }
 
 // Check returns the latest version if one is available and newer than currentVersion,
@@ -30,14 +27,11 @@ func Check(currentVersion, releasesURL, cacheFilePath string, fs afero.Fs) strin
 		return ""
 	}
 
-	if entry, err := readCache(cacheFilePath, fs); err == nil {
-		if time.Since(entry.CheckedAt) < checkInterval {
-			if entry.LatestVersion != currentVersion {
-				return entry.LatestVersion
-			}
+	c := cache.New(fs, cacheFilePath, true)
 
-			return ""
-		}
+	var latest string
+	if c.Get(cacheKeyLatestVersion, &latest) {
+		return newerVersion(latest, currentVersion)
 	}
 
 	latest, err := fetchLatest(releasesURL)
@@ -45,41 +39,19 @@ func Check(currentVersion, releasesURL, cacheFilePath string, fs afero.Fs) strin
 		return ""
 	}
 
-	_ = writeCache(cacheFilePath, latest, fs)
+	c.Set(cacheKeyLatestVersion, latest, checkInterval)
 
+	return newerVersion(latest, currentVersion)
+}
+
+// newerVersion returns latest when it differs from currentVersion, otherwise an
+// empty string.
+func newerVersion(latest, currentVersion string) string {
 	if latest != currentVersion {
 		return latest
 	}
 
 	return ""
-}
-
-func readCache(path string, fs afero.Fs) (cacheEntry, error) {
-	data, err := afero.ReadFile(fs, path)
-	if err != nil {
-		return cacheEntry{}, err
-	}
-	var entry cacheEntry
-	if err := json.Unmarshal(data, &entry); err != nil {
-		return cacheEntry{}, err
-	}
-
-	return entry, nil
-}
-
-func writeCache(path, latestVersion string, fs afero.Fs) error {
-	data, err := json.Marshal(cacheEntry{
-		CheckedAt:     time.Now(),
-		LatestVersion: latestVersion,
-	})
-	if err != nil {
-		return err
-	}
-	if err := fs.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-
-	return afero.WriteFile(fs, path, data, 0644)
 }
 
 func fetchLatest(releasesURL string) (string, error) {

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,7 +1,6 @@
 package updater_test
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -10,23 +9,20 @@ import (
 	"github.com/onsi/gomega/ghttp"
 	"github.com/spf13/afero"
 
+	"github.com/achannarasappa/ticker/v5/internal/cache"
 	"github.com/achannarasappa/ticker/v5/internal/updater"
 )
 
 const (
-	cacheFilePath  = "/cache/ticker/update-check.json"
+	cacheFilePath  = "/cache/ticker/cache.json"
 	currentVersion = "v5.0.0"
 	latestVersion  = "v5.1.0"
 )
 
-func writeCacheFile(fs afero.Fs, checkedAt time.Time, version string) {
-	type cacheEntry struct {
-		CheckedAt     time.Time `json:"checked_at"`
-		LatestVersion string    `json:"latest_version"`
-	}
-	data, _ := json.Marshal(cacheEntry{CheckedAt: checkedAt, LatestVersion: version})
-	fs.MkdirAll("/cache/ticker", 0755) //nolint:errcheck
-	afero.WriteFile(fs, cacheFilePath, data, 0644) //nolint:errcheck
+// setupCache writes a cached latest-version entry with the given time-to-live so
+// tests can simulate a fresh (positive ttl) or stale (negative ttl) cache.
+func setupCache(fs afero.Fs, version string, ttl time.Duration) {
+	cache.New(fs, cacheFilePath, true).Set("latest-version", version, ttl)
 }
 
 var _ = Describe("Check", func() {
@@ -62,7 +58,7 @@ var _ = Describe("Check", func() {
 	When("the cache is fresh", func() {
 		When("the cached version is newer than the current version", func() {
 			It("should return the cached version without making a network request", func() {
-				writeCacheFile(fs, time.Now(), latestVersion)
+				setupCache(fs, latestVersion, time.Hour)
 				output := updater.Check(currentVersion, server.URL()+"/releases/latest", cacheFilePath, fs)
 				Expect(output).To(Equal(latestVersion))
 				Expect(server.ReceivedRequests()).To(BeEmpty())
@@ -71,7 +67,7 @@ var _ = Describe("Check", func() {
 
 		When("the cached version matches the current version", func() {
 			It("should return empty without making a network request", func() {
-				writeCacheFile(fs, time.Now(), currentVersion)
+				setupCache(fs, currentVersion, time.Hour)
 				output := updater.Check(currentVersion, server.URL()+"/releases/latest", cacheFilePath, fs)
 				Expect(output).To(BeEmpty())
 				Expect(server.ReceivedRequests()).To(BeEmpty())
@@ -81,7 +77,7 @@ var _ = Describe("Check", func() {
 
 	When("the cache is stale", func() {
 		It("should fetch from the API and return the latest version", func() {
-			writeCacheFile(fs, time.Now().Add(-4*time.Hour), currentVersion)
+			setupCache(fs, currentVersion, -time.Minute)
 			output := updater.Check(currentVersion, server.URL()+"/releases/latest", cacheFilePath, fs)
 			Expect(output).To(Equal(latestVersion))
 			Expect(server.ReceivedRequests()).To(HaveLen(1))


### PR DESCRIPTION
- Introduced a caching layer to store ticker symbols and currency rates, reducing network requests and improving performance.
- Updated the CLI to support cache configuration via command-line options and configuration files.
- Enhanced the symbol retrieval process to utilize cached data when available.
- Implemented cache expiration policies for currency rates and symbol mappings.
- Added tests to verify cache functionality and ensure correct behavior when data is served from the cache.
- Refactored updater logic to use the cache for checking the latest version, simplifying the code and improving efficiency.